### PR TITLE
EDGEINV-8: Expose new subject source API

### DIFF
--- a/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
@@ -93,4 +93,10 @@ public interface InventoryClient {
 
   @GetMapping(value = "/authority-storage/authorities", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getAuthoritiesByQuery(@SpringQueryMap Object requestQueryParameters);
+
+  @GetMapping(value = "/subject-sources", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getSubjectSources(@SpringQueryMap Object requestQueryParameters);
+
+  @GetMapping(value = "/subject-types", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getSubjectTypes(@SpringQueryMap Object requestQueryParameters);
 }

--- a/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
+++ b/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
@@ -200,7 +200,8 @@ public class InventoryController implements InventoryApi {
   }
 
   @Override
-  public ResponseEntity<String> getAuthoritiesByQuery(String xOkapiTenant, String xOkapiToken, RequestQueryParameters requestQueryParameters) {
+  public ResponseEntity<String> getAuthoritiesByQuery(String xOkapiTenant, String xOkapiToken,
+      RequestQueryParameters requestQueryParameters) {
     log.info("Retrieving authorities by query {}", requestQueryParameters.getQuery());
     return ResponseEntity.ok(inventoryService.getAuthoritiesByQuery(requestQueryParameters));
   }
@@ -223,5 +224,19 @@ public class InventoryController implements InventoryApi {
       Boolean isUtf) {
     log.info("Download instance by id {} in utf format:{}", instanceId, isUtf);
     return dataExportService.downloadInstance(instanceId, isUtf);
+  }
+
+  @Override
+  public ResponseEntity<String> getSubjectSources(String xOkapiTenant, String xOkapiToken,
+      RequestQueryParameters requestQueryParameters) {
+    log.info("Retrieving subject sources by query {}", requestQueryParameters.getQuery());
+    return ResponseEntity.ok(inventoryService.getSubjectSources(requestQueryParameters));
+  }
+
+  @Override
+  public ResponseEntity<String> getSubjectTypes(String xOkapiTenant, String xOkapiToken,
+      RequestQueryParameters requestQueryParameters) {
+    log.info("Retrieving subject types by query {}", requestQueryParameters.getQuery());
+    return ResponseEntity.ok(inventoryService.getSubjectTypes(requestQueryParameters));
   }
 }

--- a/src/main/java/org/folio/edge/inventory/service/InventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/InventoryService.java
@@ -116,4 +116,12 @@ public class InventoryService {
   public String getAuthoritiesByQuery(RequestQueryParameters requestQueryParameters) {
     return inventoryClient.getAuthoritiesByQuery(requestQueryParameters);
   }
+
+  public String getSubjectSources(RequestQueryParameters requestQueryParameters) {
+    return inventoryClient.getSubjectSources(requestQueryParameters);
+  }
+
+  public String getSubjectTypes(RequestQueryParameters requestQueryParameters) {
+    return inventoryClient.getSubjectTypes(requestQueryParameters);
+  }
 }

--- a/src/main/resources/swagger.api/edge-inventory.yaml
+++ b/src/main/resources/swagger.api/edge-inventory.yaml
@@ -716,6 +716,58 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
 
+  /inventory/subject-sources:
+    get:
+      tags:
+        - subjectSources
+      operationId: getSubjectSources
+      summary: Retrieve collection of subject sources.
+      description: Retrieve collection of subject sources.
+      parameters:
+        - $ref: '#/components/parameters/x-okapi-tenant-header'
+        - $ref: '#/components/parameters/x-okapi-token-header'
+        - $ref: '#/components/parameters/request-query-parameters'
+      responses:
+        '200':
+          description: 'Calls the mod-inventory-storage GET /subject-sources API and returns the result as-is
+            The example of response: https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/examples/subject-sources.json'
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '401':
+          $ref: '#/components/responses/notAuthorizedResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
+
+  /inventory/subject-types:
+    get:
+      tags:
+        - subjectTypes
+      operationId: getSubjectTypes
+      summary: Retrieve collection of subject types.
+      description: Retrieve collection of subject types.
+      parameters:
+        - $ref: '#/components/parameters/x-okapi-tenant-header'
+        - $ref: '#/components/parameters/x-okapi-token-header'
+        - $ref: '#/components/parameters/request-query-parameters'
+      responses:
+        '200':
+          description: 'Calls the mod-inventory-storage GET /subject-types API and returns the result as-is
+            The example of response: https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/examples/subject-types.json'
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '401':
+          $ref: '#/components/responses/notAuthorizedResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
+
 components:
   schemas:
     errorResponse:
@@ -889,3 +941,5 @@ tags:
   - name: library
   - name: sourceRecords
   - name: authoritySourceRecords
+  - name: subjectSources
+  - name: subjectTypes

--- a/src/test/java/org/folio/edge/inventory/TestConstants.java
+++ b/src/test/java/org/folio/edge/inventory/TestConstants.java
@@ -27,6 +27,8 @@ public class TestConstants {
   public static final String GET_VIEW_INSTANCES_WITH_HOLDINGS_PATH = "__files/responses/view_instances_response_with_holdings.json";
   public static final String GET_VIEW_INSTANCES_WITHOUT_HOLDINGS_PATH = "__files/responses/view_instances_response_without_holdings.json";
   public static final String GET_ALTERNATIVE_TITLE_TYPES_PATH ="__files/responses/alternative_title_types_response.json";
+  public static final String GET_SUBJECT_SOURCES_PATH ="__files/responses/subject_sources_response.json";
+  public static final String GET_SUBJECT_TYPES_PATH ="__files/responses/subject_types_response.json";
   public static final String INSTITUTION_BY_ID_PATH ="__files/responses/institution_by_id_response.json";
   public static final String CAMPUS_BY_ID_PATH ="__files/responses/campus_by_id_response.json";
   public static final String LIBRARY_BY_ID_PATH ="__files/responses/library_by_id_response.json";
@@ -76,6 +78,8 @@ public class TestConstants {
   public static final String GET_VIEW_INSTANCES_URL = "/inventory/inventory-view/instances";
   public static final String GET_LOCATION_BY_ID_URL = "/inventory/locations/93b74baf-0782-431a-ba64-f74d51d68ca2";
   public static final String GET_ALTERNATIVE_TITLE_TYPES_URL = "/inventory/alternative-title-types";
+  public static final String GET_SUBJECT_SOURCES_URL = "/inventory/subject-sources";
+  public static final String GET_SUBJECT_TYPES_URL = "/inventory/subject-types";
   public static final String INSTITUTION_ID = "6ecd8132-caef-4f87-bbb0-9fc07d71357d";
   public static final String LIBRARY_ID = "5d78803e-ca04-4b4a-aeae-2c63b924518b";
   public static final String CAMPUS_ID = "62cf76b7-cca5-4d33-9217-edf42ce1a848";

--- a/src/test/java/org/folio/edge/inventory/controller/InventoryControllerIT.java
+++ b/src/test/java/org/folio/edge/inventory/controller/InventoryControllerIT.java
@@ -1,6 +1,50 @@
 package org.folio.edge.inventory.controller;
 
-import static org.folio.edge.inventory.TestConstants.*;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_BY_INVALID_AUTHORITY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_BY_NOT_FOUND_AUTHORITY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_BY_VALID_AUTHORITY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_SOURCE_RECORDS_WITH_INVALID_ID_URL;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_SOURCE_RECORDS_WITH_NON_EXISTING_ID_URL;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_SOURCE_RECORDS_WITH_VALID_ID_URL;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_SOURCE_RECORD_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.GET_ALTERNATIVE_TITLE_TYPES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_CAMPUS_BY_ID_NOT_FOUND_URL;
+import static org.folio.edge.inventory.TestConstants.GET_CAMPUS_BY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_CLASSIFICATION_TYPES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_CONTRIBUTOR_NAME_TYPES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_CONTRIBUTOR_TYPES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_EDGE_IDENTIFIER_TYPES_BY_VALID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_HOLDINGS_URL;
+import static org.folio.edge.inventory.TestConstants.GET_INSTANCE_FORMATS_URL;
+import static org.folio.edge.inventory.TestConstants.GET_INSTANCE_NOTE_TYPES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_INSTANCE_TYPES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_INSTITUTION_BY_ID_NOT_FOUND_URL;
+import static org.folio.edge.inventory.TestConstants.GET_INSTITUTION_BY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_ITEMS_URL;
+import static org.folio.edge.inventory.TestConstants.GET_LIBRARY_BY_ID_NOT_FOUND_URL;
+import static org.folio.edge.inventory.TestConstants.GET_LIBRARY_BY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_LOCATION_VALID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_MATERIAL_TYPE_BY_ID_NOT_FOUND_URL;
+import static org.folio.edge.inventory.TestConstants.GET_MATERIAL_TYPE_BY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_MODES_OF_ISSUANCE_URL;
+import static org.folio.edge.inventory.TestConstants.GET_NATURE_OF_CONTENT_TERMS_URL;
+import static org.folio.edge.inventory.TestConstants.GET_SERVICE_POINTS_VALID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_SUBJECT_SOURCES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_SUBJECT_TYPES_URL;
+import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_URL;
+import static org.folio.edge.inventory.TestConstants.INSTANCES_WITH_QUERY_URL;
+import static org.folio.edge.inventory.TestConstants.INSTANCES_WITH_QUERY_URL_NOT_FOUND;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_BY_INVALID_INSTANCE_ID_URL;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_BY_NOT_FOUND_INSTANCE_ID_URL;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_BY_VALID_INSTANCE_ID_URL;
+import static org.folio.edge.inventory.TestConstants.LANG_PARAM_INVALID_VALUE;
+import static org.folio.edge.inventory.TestConstants.LANG_PARAM_NAME;
+import static org.folio.edge.inventory.TestConstants.LANG_PARAM_VALID_VALUE;
+import static org.folio.edge.inventory.TestConstants.QUERY_PARAM_NAME;
+import static org.folio.edge.inventory.TestConstants.SOURCE_RECORDS_WITH_INVALID_ID_URL;
+import static org.folio.edge.inventory.TestConstants.SOURCE_RECORDS_WITH_NON_EXISTING_ID_URL;
+import static org.folio.edge.inventory.TestConstants.SOURCE_RECORDS_WITH_VALID_ID_URL;
+import static org.folio.edge.inventory.TestConstants.SOURCE_RECORD_RESPONSE_PATH;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
@@ -59,24 +103,24 @@ class InventoryControllerIT extends BaseIntegrationTests {
   @Test
   void getAuthority_shouldReturnAuthority_whenAuthorityIdValid() throws Exception {
     doGet(mockMvc, AUTHORITY_BY_VALID_AUTHORITY_ID_URL)
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("id", is("9eba0866-8195-457c-ac72-dbfc279cc496")))
-            .andExpect(jsonPath("personalName", is("Woodson, Jacqueline C410821")))
-            .andExpect(
-                    jsonPath("naturalId", is("n88234700410821")))
-            .andExpect(jsonPath("source", is("MARC")));
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("id", is("9eba0866-8195-457c-ac72-dbfc279cc496")))
+        .andExpect(jsonPath("personalName", is("Woodson, Jacqueline C410821")))
+        .andExpect(
+            jsonPath("naturalId", is("n88234700410821")))
+        .andExpect(jsonPath("source", is("MARC")));
   }
 
   @Test
   void getAuthority_shouldReturn400Error_whenAuthorityIdIsInvalid() throws Exception {
     doGet(mockMvc, AUTHORITY_BY_INVALID_AUTHORITY_ID_URL)
-            .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest());
   }
 
   @Test
   void getAuthority_shouldReturn404_whenAuthorityIdNotFound() throws Exception {
     doGet(mockMvc, AUTHORITY_BY_NOT_FOUND_AUTHORITY_ID_URL)
-            .andExpect(status().isNotFound());
+        .andExpect(status().isNotFound());
   }
 
   @Test
@@ -520,7 +564,8 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(jsonPath("snapshotId", is(expectedResponse.get("snapshotId"))))
         .andExpect(jsonPath("rawRecord.id", is(expectedResponse.getJSONObject("rawRecord").get("id"))))
         .andExpect(jsonPath("rawRecord.content", is(expectedResponse.getJSONObject("rawRecord").get("content"))))
-        .andExpect(jsonPath("parsedRecord.formattedContent", is(expectedResponse.getJSONObject("parsedRecord").get("formattedContent"))))
+        .andExpect(jsonPath("parsedRecord.formattedContent",
+            is(expectedResponse.getJSONObject("parsedRecord").get("formattedContent"))))
         .andExpect(jsonPath("parsedRecord.content.leader",
             is(expectedResponse.getJSONObject("parsedRecord").getJSONObject("content").get("leader"))))
         .andExpect(jsonPath("parsedRecord.content.fields", hasSize(
@@ -547,34 +592,36 @@ class InventoryControllerIT extends BaseIntegrationTests {
     JSONObject expectedResponse = new JSONObject(expectedString);
 
     doGet(mockMvc, AUTHORITY_SOURCE_RECORDS_WITH_VALID_ID_URL)
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("id", is(expectedResponse.get("id"))))
-            .andExpect(jsonPath("snapshotId", is(expectedResponse.get("snapshotId"))))
-            .andExpect(jsonPath("rawRecord.id", is(expectedResponse.getJSONObject("rawRecord").get("id"))))
-            .andExpect(jsonPath("rawRecord.content", is(expectedResponse.getJSONObject("rawRecord").get("content"))))
-            .andExpect(jsonPath("parsedRecord.formattedContent", is(expectedResponse.getJSONObject("parsedRecord").get("formattedContent"))))
-            .andExpect(jsonPath("parsedRecord.content.leader",
-                    is(expectedResponse.getJSONObject("parsedRecord").getJSONObject("content").get("leader"))))
-            .andExpect(jsonPath("parsedRecord.content.fields", hasSize(
-                    expectedResponse.getJSONObject("parsedRecord").getJSONObject("content").getJSONArray("fields").length())))
-            .andExpect(jsonPath("externalIdsHolder.authorityId",
-                    is(expectedResponse.getJSONObject("externalIdsHolder").get("authorityId"))));
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("id", is(expectedResponse.get("id"))))
+        .andExpect(jsonPath("snapshotId", is(expectedResponse.get("snapshotId"))))
+        .andExpect(jsonPath("rawRecord.id", is(expectedResponse.getJSONObject("rawRecord").get("id"))))
+        .andExpect(jsonPath("rawRecord.content", is(expectedResponse.getJSONObject("rawRecord").get("content"))))
+        .andExpect(jsonPath("parsedRecord.formattedContent",
+            is(expectedResponse.getJSONObject("parsedRecord").get("formattedContent"))))
+        .andExpect(jsonPath("parsedRecord.content.leader",
+            is(expectedResponse.getJSONObject("parsedRecord").getJSONObject("content").get("leader"))))
+        .andExpect(jsonPath("parsedRecord.content.fields", hasSize(
+            expectedResponse.getJSONObject("parsedRecord").getJSONObject("content").getJSONArray("fields").length())))
+        .andExpect(jsonPath("externalIdsHolder.authorityId",
+            is(expectedResponse.getJSONObject("externalIdsHolder").get("authorityId"))));
   }
 
   @Test
   void getAuthoritySourceRecord_shouldReturn400Error_whenAuthorityIdIsInvalid() throws Exception {
     doGet(mockMvc, AUTHORITY_SOURCE_RECORDS_WITH_INVALID_ID_URL)
-            .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest());
   }
 
   @Test
   void getAuthoritySourceRecord_shouldReturn404_whenInstanceIdNotFound() throws Exception {
     doGet(mockMvc, AUTHORITY_SOURCE_RECORDS_WITH_NON_EXISTING_ID_URL)
-            .andExpect(status().isNotFound());
+        .andExpect(status().isNotFound());
   }
 
   @Test
-  void getContributorNameTypes_shouldReturn200WithEmptyRecords_whenNoContributorNameTypesFoundByQuery() throws Exception {
+  void getContributorNameTypes_shouldReturn200WithEmptyRecords_whenNoContributorNameTypesFoundByQuery()
+      throws Exception {
     doGetWithParams(mockMvc, GET_CONTRIBUTOR_NAME_TYPES_URL, QUERY_PARAM_NAME, "id==test")
         .andExpect(status().isOk())
         .andExpect(jsonPath("totalRecords", is(0)));
@@ -600,7 +647,8 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(header().string("Content-Disposition",
             "attachment; filename=\"" + "0831576a-c421-47dd-9285-ebab3351faa8-utf.mrc" + "\""))
         .andExpect(result -> {
-          byte[] expectedContent = TestUtil.readFileBytesFromResources("__files/responses/0831576a-c421-47dd-9285-ebab3351faa8-utf.mrc");
+          byte[] expectedContent = TestUtil.readFileBytesFromResources(
+              "__files/responses/0831576a-c421-47dd-9285-ebab3351faa8-utf.mrc");
           byte[] actualContent = result.getResponse().getContentAsByteArray();
           Assertions.assertArrayEquals(expectedContent, actualContent);
         });
@@ -614,7 +662,8 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(header().string("Content-Disposition",
             "attachment; filename=\"" + "0831576a-c421-47dd-9285-ebab3351faa8-marc8.mrc" + "\""))
         .andExpect(result -> {
-          byte[] expectedContent = TestUtil.readFileBytesFromResources("__files/responses/0831576a-c421-47dd-9285-ebab3351faa8-marc8.mrc");
+          byte[] expectedContent = TestUtil.readFileBytesFromResources(
+              "__files/responses/0831576a-c421-47dd-9285-ebab3351faa8-marc8.mrc");
           byte[] actualContent = result.getResponse().getContentAsByteArray();
           Assertions.assertArrayEquals(expectedContent, actualContent);
         });
@@ -626,7 +675,8 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(status().isInternalServerError())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.code").value(500))
-        .andExpect(jsonPath("$.errorMessage").value("Couldn't find authority in db for ID: 1831576a-c421-47dd-9285-ebab3351faa8"));
+        .andExpect(jsonPath("$.errorMessage").value(
+            "Couldn't find authority in db for ID: 1831576a-c421-47dd-9285-ebab3351faa8"));
   }
 
   @Test
@@ -637,7 +687,8 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(header().string("Content-Disposition",
             "attachment; filename=\"" + "0684a01d-a83a-4ea7-8985-37dd59a751b2-utf.mrc" + "\""))
         .andExpect(result -> {
-          byte[] expectedContent = TestUtil.readFileBytesFromResources("__files/responses/0684a01d-a83a-4ea7-8985-37dd59a751b2-utf.mrc");
+          byte[] expectedContent = TestUtil.readFileBytesFromResources(
+              "__files/responses/0684a01d-a83a-4ea7-8985-37dd59a751b2-utf.mrc");
           byte[] actualContent = result.getResponse().getContentAsByteArray();
           Assertions.assertArrayEquals(expectedContent, actualContent);
         });
@@ -651,7 +702,8 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(header().string("Content-Disposition",
             "attachment; filename=\"" + "0684a01d-a83a-4ea7-8985-37dd59a751b2-marc8.mrc" + "\""))
         .andExpect(result -> {
-          byte[] expectedContent = TestUtil.readFileBytesFromResources("__files/responses/0684a01d-a83a-4ea7-8985-37dd59a751b2-marc8.mrc");
+          byte[] expectedContent = TestUtil.readFileBytesFromResources(
+              "__files/responses/0684a01d-a83a-4ea7-8985-37dd59a751b2-marc8.mrc");
           byte[] actualContent = result.getResponse().getContentAsByteArray();
           Assertions.assertArrayEquals(expectedContent, actualContent);
         });
@@ -663,6 +715,53 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(status().isInternalServerError())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.code").value(500))
-        .andExpect(jsonPath("$.errorMessage").value("Couldn't find instance in db for ID: 1831576a-c421-47dd-9285-ebab3351faa8"));
+        .andExpect(jsonPath("$.errorMessage").value(
+            "Couldn't find instance in db for ID: 1831576a-c421-47dd-9285-ebab3351faa8"));
+  }
+
+  @Test
+  void getSubjectSources_shouldReturnSubjectSources() throws Exception {
+    doGetWithParams(mockMvc, GET_SUBJECT_SOURCES_URL, LANG_PARAM_NAME, LANG_PARAM_VALID_VALUE)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("subjectSources[0].id", is("06b2cbd8-66bf-4956-9d90-97c9776365b8")))
+        .andExpect(jsonPath("subjectSources[0].name", is("Library of Congress Subject Headings")))
+        .andExpect(jsonPath("subjectSources[0].source", is("folio")))
+        .andExpect(jsonPath("subjectSources[1].id", is("f9e5b41b-8d5b-47d3-91d0-ca9004796400")))
+        .andExpect(
+            jsonPath("subjectSources[1].name", is("Library of Congress Children's and Young Adults' Subject Headings")))
+        .andExpect(jsonPath("subjectSources[1].source", is("folio")))
+        .andExpect(jsonPath("subjectSources[2].id", is("6e09d47d-95e2-4d8a-831b-f777b8ef6d99")))
+        .andExpect(jsonPath("subjectSources[2].name", is("Non-medical Subject Headings")))
+        .andExpect(jsonPath("subjectSources[2].source", is("local")))
+        .andExpect(jsonPath("totalRecords", is(3)));
+  }
+
+  @Test
+  void getSubjectSources_shouldReturn400Error_whenLangParameterIsInValid() throws Exception {
+    doGetWithParams(mockMvc, GET_SUBJECT_SOURCES_URL, LANG_PARAM_NAME, LANG_PARAM_INVALID_VALUE)
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getSubjectTypes_shouldReturnSubjectTypes() throws Exception {
+    doGetWithParams(mockMvc, GET_SUBJECT_TYPES_URL, LANG_PARAM_NAME, LANG_PARAM_VALID_VALUE)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("subjectTypes[0].id", is("06b2cbd8-66bf-4956-9d90-97c9776365b8")))
+        .andExpect(jsonPath("subjectTypes[0].name", is("Personal name")))
+        .andExpect(jsonPath("subjectTypes[0].source", is("folio")))
+        .andExpect(jsonPath("subjectTypes[1].id", is("f9e5b41b-8d5b-47d3-91d0-ca9004796400")))
+        .andExpect(
+            jsonPath("subjectTypes[1].name", is("Occupation")))
+        .andExpect(jsonPath("subjectTypes[1].source", is("folio")))
+        .andExpect(jsonPath("subjectTypes[2].id", is("6e09d47d-95e2-4d8a-831b-f777b8ef6d99")))
+        .andExpect(jsonPath("subjectTypes[2].name", is("Phone number")))
+        .andExpect(jsonPath("subjectTypes[2].source", is("local")))
+        .andExpect(jsonPath("totalRecords", is(3)));
+  }
+
+  @Test
+  void getSubjectTypes_shouldReturn400Error_whenLangParameterIsInValid() throws Exception {
+    doGetWithParams(mockMvc, GET_SUBJECT_TYPES_URL, LANG_PARAM_NAME, LANG_PARAM_INVALID_VALUE)
+        .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
@@ -1,6 +1,37 @@
 package org.folio.edge.inventory.service;
 
-import static org.folio.edge.inventory.TestConstants.*;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.AUTHORITY_SOURCE_RECORD_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.CAMPUS_BY_ID_PATH;
+import static org.folio.edge.inventory.TestConstants.CAMPUS_ID;
+import static org.folio.edge.inventory.TestConstants.CLASSIFICATION_TYPES_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.CONTRIBUTOR_NAME_TYPES_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.CONTRIBUTOR_TYPES_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.GET_ALTERNATIVE_TITLE_TYPES_PATH;
+import static org.folio.edge.inventory.TestConstants.GET_SUBJECT_SOURCES_PATH;
+import static org.folio.edge.inventory.TestConstants.GET_SUBJECT_TYPES_PATH;
+import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_PATH;
+import static org.folio.edge.inventory.TestConstants.HOLDINGS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.IDENTIFIER_TYPES_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_FORMATS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_NOTE_TYPES_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_TYPES_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTITUTION_BY_ID_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTITUTION_ID;
+import static org.folio.edge.inventory.TestConstants.ITEMS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.LANG_PARAM_VALID_VALUE;
+import static org.folio.edge.inventory.TestConstants.LIBRARY_BY_ID_PATH;
+import static org.folio.edge.inventory.TestConstants.LIBRARY_ID;
+import static org.folio.edge.inventory.TestConstants.LOCATIONS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.MATERIAL_TYPE_BY_ID_PATH;
+import static org.folio.edge.inventory.TestConstants.MATERIAL_TYPE_ID;
+import static org.folio.edge.inventory.TestConstants.MODES_OF_ISSUANCE_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.NATURE_OF_CONTENT_TERMS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.SERVICE_POINTS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.SOURCE_RECORD_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.VALID_AUTHORITY_ID;
+import static org.folio.edge.inventory.TestConstants.VALID_INSTANCE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -50,8 +81,8 @@ class InventoryServiceTest {
   void getAuthorityById_shouldReturnAuthority() throws JSONException {
     String expectedInventoryContent = TestUtil.readFileContentFromResources(AUTHORITY_RESPONSE_PATH);
     when(inventoryClient
-            .getAuthority(VALID_AUTHORITY_ID))
-            .thenReturn(expectedInventoryContent);
+        .getAuthority(VALID_AUTHORITY_ID))
+        .thenReturn(expectedInventoryContent);
 
     JSONObject actualAuthority = new JSONObject(inventoryService.getAuthority(VALID_AUTHORITY_ID));
 
@@ -96,7 +127,8 @@ class InventoryServiceTest {
 
   @Test
   void getClassificationTypes_shouldReturnClassificationTypes() throws JSONException {
-    String expectedClassificationTypesContent = TestUtil.readFileContentFromResources(CLASSIFICATION_TYPES_RESPONSE_PATH);
+    String expectedClassificationTypesContent = TestUtil.readFileContentFromResources(
+        CLASSIFICATION_TYPES_RESPONSE_PATH);
     RequestQueryParameters requestQueryParameters = new RequestQueryParameters();
     when(inventoryClient
         .getClassificationTypes(requestQueryParameters))
@@ -409,8 +441,8 @@ class InventoryServiceTest {
   void getAuthoritySourceRecordById_shouldReturnAuthoritySourceRecord() throws JSONException {
     String expectedSourceRecord = TestUtil.readFileContentFromResources(AUTHORITY_SOURCE_RECORD_RESPONSE_PATH);
     when(inventoryClient
-            .getAuthoritySourceRecords(VALID_AUTHORITY_ID))
-            .thenReturn(expectedSourceRecord);
+        .getAuthoritySourceRecords(VALID_AUTHORITY_ID))
+        .thenReturn(expectedSourceRecord);
 
     JSONObject expected = new JSONObject(expectedSourceRecord);
     JSONObject actual = new JSONObject(inventoryClient.getAuthoritySourceRecords(VALID_AUTHORITY_ID));
@@ -421,6 +453,56 @@ class InventoryServiceTest {
     assertEquals("73f57292-6c90-4a4e-8b16-21cf383a62b5", actual.getJSONObject("rawRecord").get("id"));
     assertEquals(expected.getJSONObject("rawRecord").get("content"), actual.getJSONObject("rawRecord").get("content"));
     assertEquals("01522cz  a2200313n  4500",
-            actual.getJSONObject("parsedRecord").getJSONObject("content").get("leader"));
+        actual.getJSONObject("parsedRecord").getJSONObject("content").get("leader"));
+  }
+
+  @Test
+  void getSubjectSources_shouldReturnSubjectSources() throws JSONException {
+    String expectedInstanceFormatsResponse = TestUtil.readFileContentFromResources(GET_SUBJECT_SOURCES_PATH);
+    RequestQueryParameters requestQueryParameters = new RequestQueryParameters();
+    when(inventoryClient
+        .getSubjectSources(requestQueryParameters))
+        .thenReturn(expectedInstanceFormatsResponse);
+
+    JSONObject itemsJson = new JSONObject(inventoryService.getSubjectSources(requestQueryParameters));
+    JSONObject firstSubjectSource = itemsJson.getJSONArray("subjectSources").getJSONObject(0);
+    JSONObject secondSubjectSource = itemsJson.getJSONArray("subjectSources").getJSONObject(1);
+    JSONObject thirdSubjectSource = itemsJson.getJSONArray("subjectSources").getJSONObject(2);
+
+    assertEquals(3, itemsJson.get(TOTAL_RECORDS));
+    assertEquals("06b2cbd8-66bf-4956-9d90-97c9776365b8", firstSubjectSource.get(ID));
+    assertEquals("Library of Congress Subject Headings", firstSubjectSource.get(NAME));
+    assertEquals("folio", firstSubjectSource.get(SOURCE));
+    assertEquals("f9e5b41b-8d5b-47d3-91d0-ca9004796400", secondSubjectSource.get(ID));
+    assertEquals("Library of Congress Children's and Young Adults' Subject Headings", secondSubjectSource.get(NAME));
+    assertEquals("folio", secondSubjectSource.get(SOURCE));
+    assertEquals("6e09d47d-95e2-4d8a-831b-f777b8ef6d99", thirdSubjectSource.get(ID));
+    assertEquals("Non-medical Subject Headings", thirdSubjectSource.get(NAME));
+    assertEquals("local", thirdSubjectSource.get(SOURCE));
+  }
+
+  @Test
+  void getSubjectTypes_shouldReturnSubjectTypes() throws JSONException {
+    String expectedInstanceFormatsResponse = TestUtil.readFileContentFromResources(GET_SUBJECT_TYPES_PATH);
+    RequestQueryParameters requestQueryParameters = new RequestQueryParameters();
+    when(inventoryClient
+        .getSubjectTypes(requestQueryParameters))
+        .thenReturn(expectedInstanceFormatsResponse);
+
+    JSONObject itemsJson = new JSONObject(inventoryService.getSubjectTypes(requestQueryParameters));
+    JSONObject firstSubjectType = itemsJson.getJSONArray("subjectTypes").getJSONObject(0);
+    JSONObject secondSubjectType = itemsJson.getJSONArray("subjectTypes").getJSONObject(1);
+    JSONObject thirdSubjectType = itemsJson.getJSONArray("subjectTypes").getJSONObject(2);
+
+    assertEquals(3, itemsJson.get(TOTAL_RECORDS));
+    assertEquals("06b2cbd8-66bf-4956-9d90-97c9776365b8", firstSubjectType.get(ID));
+    assertEquals("Personal name", firstSubjectType.get(NAME));
+    assertEquals("folio", firstSubjectType.get(SOURCE));
+    assertEquals("f9e5b41b-8d5b-47d3-91d0-ca9004796400", secondSubjectType.get(ID));
+    assertEquals("Occupation", secondSubjectType.get(NAME));
+    assertEquals("folio", secondSubjectType.get(SOURCE));
+    assertEquals("6e09d47d-95e2-4d8a-831b-f777b8ef6d99", thirdSubjectType.get(ID));
+    assertEquals("Phone number", thirdSubjectType.get(NAME));
+    assertEquals("local", thirdSubjectType.get(SOURCE));
   }
 }

--- a/src/test/resources/__files/responses/subject_sources_response.json
+++ b/src/test/resources/__files/responses/subject_sources_response.json
@@ -1,0 +1,20 @@
+{
+  "subjectSources": [
+    {
+      "id": "06b2cbd8-66bf-4956-9d90-97c9776365b8",
+      "name": "Library of Congress Subject Headings",
+      "source": "folio"
+    },
+    {
+      "id": "f9e5b41b-8d5b-47d3-91d0-ca9004796400",
+      "name": "Library of Congress Children's and Young Adults' Subject Headings",
+      "source": "folio"
+    },
+    {
+      "id": "6e09d47d-95e2-4d8a-831b-f777b8ef6d99",
+      "name": "Non-medical Subject Headings",
+      "source": "local"
+    }
+  ],
+  "totalRecords": 3
+}

--- a/src/test/resources/__files/responses/subject_types_response.json
+++ b/src/test/resources/__files/responses/subject_types_response.json
@@ -1,0 +1,20 @@
+{
+  "subjectTypes": [
+    {
+      "id": "06b2cbd8-66bf-4956-9d90-97c9776365b8",
+      "name": "Personal name",
+      "source": "folio"
+    },
+    {
+      "id": "f9e5b41b-8d5b-47d3-91d0-ca9004796400",
+      "name": "Occupation",
+      "source": "folio"
+    },
+    {
+      "id": "6e09d47d-95e2-4d8a-831b-f777b8ef6d99",
+      "name": "Phone number",
+      "source": "local"
+    }
+  ],
+  "totalRecords": 3
+}

--- a/src/test/resources/mappings/subject_sources.json
+++ b/src/test/resources/mappings/subject_sources.json
@@ -1,0 +1,17 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "/subject-sources?offset=0&limit=10&lang=en"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/subject_sources_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/mappings/subject_types.json
+++ b/src/test/resources/mappings/subject_types.json
@@ -1,0 +1,17 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "/subject-types?offset=0&limit=10&lang=en"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/subject_types_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Approach
- Implement new endpoints: 
- GET collection of /subject-sources
- GET collection of /subject-types

## Checklist
<!--
  This serves as gentle reminder for common tasks. Confirm these are done and check all that apply.
-->
- [ ] Documentation updated
- [x] Tests cover new or modified code
- [ ] New dependencies added
- [ ] Includes breaking changes
- [ ] Module permissions been updated when calling new APIs
- [ ] The interface version has been bumped
- [ ] Coordinated corresponding changes in the UI and other backend modules that consume new interface 

## Result
#### /subject-sources
<img width="787" alt="image" src="https://github.com/user-attachments/assets/ab5bf7dc-dc50-4960-a23a-2c57e56fede6" />
#### /subject-types
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/8c12f0e3-aee0-445d-bd68-7092e92a28de" />