### PR TITLE
feature/DE99777: Material Type - updated the logic and added isCentra…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-inventory</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <name>edge-inventory</name>
   <description>Provides an ability to retrieve inventory information from FOLIO</description>
   <packaging>jar</packaging>

--- a/src/main/java/org/folio/edge/inventory/client/ConsortiaClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/ConsortiaClient.java
@@ -10,6 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "consortia", configuration = InventoryClientConfig.class)
 public interface ConsortiaClient {
 
-  @GetMapping(value = "/{consortiumId}/tenants", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @GetMapping(value = "/consortia/{consortiumId}/tenants", consumes = MediaType.APPLICATION_JSON_VALUE)
   TenantCollection getTenants(@PathVariable String consortiumId);
 }

--- a/src/main/java/org/folio/edge/inventory/client/ConsortiaClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/ConsortiaClient.java
@@ -1,0 +1,15 @@
+package org.folio.edge.inventory.client;
+
+import org.folio.edge.inventory.config.InventoryClientConfig;
+import org.folio.inventory.domain.dto.TenantCollection;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "consortia", configuration = InventoryClientConfig.class)
+public interface ConsortiaClient {
+
+  @GetMapping(value = "/{consortiumId}/tenants", consumes = MediaType.APPLICATION_JSON_VALUE)
+  TenantCollection getTenants(@PathVariable String consortiumId);
+}

--- a/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
@@ -71,7 +71,8 @@ public interface InventoryClient {
   String getInstanceNoteTypes(@SpringQueryMap Object requestQueryParameters);
 
   @GetMapping(value = "/inventory-view/instances", consumes = MediaType.APPLICATION_JSON_VALUE)
-  String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters, @RequestParam Boolean withBoundedItems);
+  String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters,
+      @RequestParam Boolean withBoundedItems);
 
   @GetMapping(value = "/inventory-view/instances", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters,
@@ -82,6 +83,10 @@ public interface InventoryClient {
 
   @GetMapping(value = "/material-types/{materialTypeId}", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getMaterialTypeById(@PathVariable("materialTypeId") String materialTypeId);
+
+  @GetMapping(value = "/material-types/{materialTypeId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getMaterialTypeById(@PathVariable("materialTypeId") String materialTypeId,
+      @RequestHeader(XOkapiHeaders.TENANT) String tenantId);
 
   @GetMapping(value = "/source-storage/records/{instanceId}/formatted?idType=INSTANCE", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getSourceRecords(@PathVariable("instanceId") String instanceId);

--- a/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
@@ -77,7 +77,8 @@ public interface InventoryClient {
   String getInstanceNoteTypes(@SpringQueryMap Object requestQueryParameters);
 
   @GetMapping(value = "/inventory-view/instances", consumes = MediaType.APPLICATION_JSON_VALUE)
-  String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters, @RequestParam Boolean withBoundedItems);
+  String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters,
+      @RequestParam Boolean withBoundedItems);
 
   @GetMapping(value = "/inventory-view/instances", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters,
@@ -88,6 +89,10 @@ public interface InventoryClient {
 
   @GetMapping(value = "/material-types/{materialTypeId}", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getMaterialTypeById(@PathVariable("materialTypeId") String materialTypeId);
+
+  @GetMapping(value = "/material-types/{materialTypeId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getMaterialTypeById(@PathVariable("materialTypeId") String materialTypeId,
+      @RequestHeader(XOkapiHeaders.TENANT) String tenantId);
 
   @GetMapping(value = "/source-storage/records/{instanceId}/formatted?idType=INSTANCE", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getSourceRecords(@PathVariable("instanceId") String instanceId);

--- a/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
@@ -22,6 +22,9 @@ public interface InventoryClient {
   @GetMapping(value = "/holdings-storage/holdings", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getHoldings(@SpringQueryMap Object requestQueryParameters);
 
+  @GetMapping(value = "/holdings-storage/holdings", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getHoldings(@SpringQueryMap Object requestQueryParameters, @RequestHeader(XOkapiHeaders.TENANT) String tenantId);
+
   @GetMapping(value = "/identifier-types", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getIdentifierTypes(@SpringQueryMap Object requestQueryParameters);
 
@@ -54,6 +57,9 @@ public interface InventoryClient {
 
   @GetMapping(value = "/inventory/items", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getItems(@SpringQueryMap Object requestQueryParameters);
+
+  @GetMapping(value = "/inventory/items", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getItems(@SpringQueryMap Object requestQueryParameters, @RequestHeader(XOkapiHeaders.TENANT) String tenantId);
 
   @GetMapping(value = "/instance-types", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getInstanceTypes(@SpringQueryMap Object requestQueryParameters);

--- a/src/main/java/org/folio/edge/inventory/client/SearchClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/SearchClient.java
@@ -2,9 +2,11 @@ package org.folio.edge.inventory.client;
 
 import org.folio.edge.inventory.config.InventoryClientConfig;
 import org.folio.inventory.domain.dto.FacetResponse;
+import org.folio.inventory.domain.dto.HoldingResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "search", configuration = InventoryClientConfig.class)
@@ -24,5 +26,8 @@ public interface SearchClient {
 
   @GetMapping(value = "/search/consortium/campuses")
   String getConsortiumCampuses(@RequestParam String id);
+
+  @GetMapping(value = "/search/consortium/holding/{id}")
+  HoldingResponse getConsortiumHolding(@PathVariable String id);
 
 }

--- a/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
+++ b/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
@@ -41,6 +41,10 @@ public class InventoryController implements InventoryApi {
   public ResponseEntity<String> getHoldings(String xOkapiTenant, String xOkapiToken,
       RequestQueryParameters requestQueryParameters) {
     log.info("Retrieving holdings  by query {}", requestQueryParameters.getQuery());
+    if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
+      log.info("Fetching holdings for consortia....");
+      return ResponseEntity.ok(ecsInventoryService.getEcsInventoryHoldings(requestQueryParameters));
+    }
     return ResponseEntity.ok(inventoryService.getHoldings(requestQueryParameters));
   }
 
@@ -130,6 +134,10 @@ public class InventoryController implements InventoryApi {
   public ResponseEntity<String> getItems(String xOkapiTenant, String xOkapiToken,
       RequestQueryParameters requestQueryParameters) {
     log.info("Retrieving items by query {}", requestQueryParameters.getQuery());
+    if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
+      log.info("Fetching items for consortia....");
+      return ResponseEntity.ok(ecsInventoryService.getEcsInventoryItems(requestQueryParameters));
+    }
     return ResponseEntity.ok(inventoryService.getItems(requestQueryParameters));
   }
 

--- a/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
+++ b/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
@@ -6,6 +6,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.service.DataExportService;
 import org.folio.edge.inventory.service.EcsInventoryService;
 import org.folio.edge.inventory.service.EcsLocationsService;
+import org.folio.edge.inventory.service.EcsMaterialTypeService;
 import org.folio.edge.inventory.service.InventoryService;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.folio.inventory.rest.resource.InventoryApi;
@@ -22,6 +23,7 @@ public class InventoryController implements InventoryApi {
   private final InventoryService inventoryService;
   private final DataExportService dataExportService;
   private final EcsInventoryService ecsInventoryService;
+  private final EcsMaterialTypeService materialTypeService;
   private final EcsLocationsService ecsLocationsService;
 
   @Override
@@ -174,7 +176,8 @@ public class InventoryController implements InventoryApi {
       RequestQueryParameters requestQueryParameters, Boolean withBoundedItems) {
     log.info("Retrieving inventory view instances by query {}", requestQueryParameters.getQuery());
     if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
-      return ResponseEntity.ok(ecsInventoryService.getEcsInventoryViewInstances(requestQueryParameters, withBoundedItems));
+      return ResponseEntity.ok(
+          ecsInventoryService.getEcsInventoryViewInstances(requestQueryParameters, withBoundedItems));
     }
     return ResponseEntity.ok(inventoryService.getInventoryViewInstances(requestQueryParameters, withBoundedItems));
   }
@@ -182,6 +185,10 @@ public class InventoryController implements InventoryApi {
   @Override
   public ResponseEntity<String> getMaterialTypeById(String materialTypeId, String xOkapiTenant, String xOkapiToken) {
     log.info("Retrieving material type by id {}", materialTypeId);
+    if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
+      return ResponseEntity.ok(
+          materialTypeService.getEcsMaterialTypeById(materialTypeId));
+    }
     return ResponseEntity.ok(inventoryService.getMaterialTypeById(materialTypeId));
   }
 

--- a/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
+++ b/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
@@ -6,6 +6,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.service.DataExportService;
 import org.folio.edge.inventory.service.EcsInventoryService;
 import org.folio.edge.inventory.service.EcsLocationsService;
+import org.folio.edge.inventory.service.EcsMaterialTypeService;
 import org.folio.edge.inventory.service.InventoryService;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.folio.inventory.rest.resource.InventoryApi;
@@ -22,6 +23,7 @@ public class InventoryController implements InventoryApi {
   private final InventoryService inventoryService;
   private final DataExportService dataExportService;
   private final EcsInventoryService ecsInventoryService;
+  private final EcsMaterialTypeService materialTypeService;
   private final EcsLocationsService ecsLocationsService;
 
   @Override
@@ -166,7 +168,8 @@ public class InventoryController implements InventoryApi {
       RequestQueryParameters requestQueryParameters, Boolean withBoundedItems) {
     log.info("Retrieving inventory view instances by query {}", requestQueryParameters.getQuery());
     if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
-      return ResponseEntity.ok(ecsInventoryService.getEcsInventoryViewInstances(requestQueryParameters, withBoundedItems));
+      return ResponseEntity.ok(
+          ecsInventoryService.getEcsInventoryViewInstances(requestQueryParameters, withBoundedItems));
     }
     return ResponseEntity.ok(inventoryService.getInventoryViewInstances(requestQueryParameters, withBoundedItems));
   }
@@ -174,6 +177,10 @@ public class InventoryController implements InventoryApi {
   @Override
   public ResponseEntity<String> getMaterialTypeById(String materialTypeId, String xOkapiTenant, String xOkapiToken) {
     log.info("Retrieving material type by id {}", materialTypeId);
+    if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
+      return ResponseEntity.ok(
+          materialTypeService.getEcsMaterialTypeById(materialTypeId));
+    }
     return ResponseEntity.ok(inventoryService.getMaterialTypeById(materialTypeId));
   }
 

--- a/src/main/java/org/folio/edge/inventory/models/InventoryViewJsonFields.java
+++ b/src/main/java/org/folio/edge/inventory/models/InventoryViewJsonFields.java
@@ -6,5 +6,6 @@ public class InventoryViewJsonFields {
   public static final String INSTANCE_ID = "instanceId";
   public static final String ID = "id";
   public static final String HOLDINGS_RECORDS = "holdingsRecords";
+  public static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
   public static final String ITEMS = "items";
 }

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -1,6 +1,7 @@
 package org.folio.edge.inventory.service;
 
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.HOLDINGS_RECORDS;
+import static org.folio.edge.inventory.models.InventoryViewJsonFields.HOLDINGS_RECORD_ID;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.ID;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.INSTANCES;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.INSTANCE_ID;
@@ -8,11 +9,13 @@ import static org.folio.edge.inventory.models.InventoryViewJsonFields.ITEMS;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.TOTAL_RECORDS;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.client.InventoryClient;
@@ -32,6 +35,8 @@ import org.springframework.stereotype.Service;
 public class EcsInventoryService {
 
   public static final String FACET = "holdings.tenantId";
+  private static final Pattern HOLDINGS_ID_PATTERN = Pattern.compile(HOLDINGS_RECORD_ID + "==\\(([^)]+)\\)");
+  private static final Pattern INSTANCE_ID_PATTERN = Pattern.compile("(instance(?:\\.id|Id))==([a-fA-F0-9\\-]{36})");
   private final UsersClient usersClient;
   private final InventoryClient inventoryClient;
   private final SearchClient searchClient;
@@ -106,16 +111,125 @@ public class EcsInventoryService {
   }
 
   private List<InstanceTenants> getInstanceTenants(List<String> instanceIds) {
+    return instanceIds.parallelStream().map(this::getInstanceTenants).toList();
+  }
+
+  private InstanceTenants getInstanceTenants(String instanceId) {
     var context = (FolioExecutionContext) folioExecutionContext.getInstance();
-    return instanceIds.parallelStream()
-        .map(instanceId -> context.execute(() -> {
-          var response = searchClient.getInstanceFacet(FACET, "id==" + instanceId);
-          if (response.getFacets().getHoldingsTenantId().getTotalRecords() == 0) {
-            return new InstanceTenants(instanceId, Collections.EMPTY_LIST);
-          }
-          var tenantIds = response.getFacets().getHoldingsTenantId().getValues()
-              .stream().map(value -> value.getId()).toList();
-          return new InstanceTenants(instanceId, tenantIds);
-        })).toList();
+    return context.execute(() -> {
+      var response = searchClient.getInstanceFacet(FACET, "id==" + instanceId);
+      if (response.getFacets().getHoldingsTenantId().getTotalRecords() == 0) {
+        return new InstanceTenants(instanceId, Collections.EMPTY_LIST);
+      }
+      var tenantIds = response.getFacets().getHoldingsTenantId().getValues()
+          .stream().map(value -> value.getId()).toList();
+      return new InstanceTenants(instanceId, tenantIds);
+    });
+  }
+
+  public String getEcsInventoryHoldings(RequestQueryParameters requestQueryParameters) {
+    var query = requestQueryParameters.getQuery();
+    var instanceId = parseInstanceId(query);
+    var instanceTenants = getInstanceTenants(instanceId);
+    var tenantHoldings = getHoldings(instanceTenants, requestQueryParameters);
+    return flattenHoldings(tenantHoldings);
+  }
+
+  private List<JsonNode> getHoldings(InstanceTenants instanceTenants, RequestQueryParameters requestQueryParameters) {
+    var context = (FolioExecutionContext) folioExecutionContext.getInstance();
+    return instanceTenants.tenantIds().parallelStream()
+        .map(tenantId -> context.execute(() -> jsonConverter
+            .readAsTree(inventoryClient.getHoldings(requestQueryParameters, tenantId))))
+        .toList();
+  }
+
+  private String flattenHoldings(List<JsonNode> tenantHoldings) {
+    var response = JsonNodeFactory.instance.objectNode();
+    var mergedHoldings = JsonNodeFactory.instance.arrayNode();
+    int totalRecordsSum = 0;
+    if (tenantHoldings == null || tenantHoldings.isEmpty()) {
+      response.set(HOLDINGS_RECORDS, mergedHoldings);
+      response.put(TOTAL_RECORDS, totalRecordsSum);
+      return response.toString();
+    }
+
+    for (JsonNode node : tenantHoldings) {
+      mergedHoldings.addAll(node.withArrayProperty(HOLDINGS_RECORDS));
+      var totalRecordsNode = node.get(TOTAL_RECORDS);
+      if (totalRecordsNode != null && totalRecordsNode.isInt()) {
+        totalRecordsSum += totalRecordsNode.intValue();
+      }
+    }
+
+    response.set(HOLDINGS_RECORDS, mergedHoldings);
+    response.put(TOTAL_RECORDS, totalRecordsSum);
+    return response.toString();
+  }
+
+  public String getEcsInventoryItems(RequestQueryParameters requestQueryParameters) {
+    var query = requestQueryParameters.getQuery();
+    String instanceId;
+    if (query.contains(HOLDINGS_RECORD_ID)) {
+      var holdingId = parseHoldingId(query);
+      var holdingResponse = searchClient.getConsortiumHolding(holdingId);
+      instanceId = holdingResponse.getInstanceId();
+    } else {
+      instanceId = parseInstanceId(query);
+    }
+
+    var instanceTenants = getInstanceTenants(instanceId);
+    var tenantItems = getItems(instanceTenants, requestQueryParameters);
+    return flattenItems(tenantItems);
+  }
+
+  private String flattenItems(List<JsonNode> tenantItems) {
+    var response = JsonNodeFactory.instance.objectNode();
+    var mergedItems = JsonNodeFactory.instance.arrayNode();
+    int totalRecordsSum = 0;
+    if (tenantItems == null || tenantItems.isEmpty()) {
+      response.set(ITEMS, mergedItems);
+      response.put(TOTAL_RECORDS, totalRecordsSum);
+      return response.toString();
+    }
+
+    for (JsonNode node : tenantItems) {
+      mergedItems.addAll(node.withArrayProperty(ITEMS));
+      var totalRecordsNode = node.get(TOTAL_RECORDS);
+      if (totalRecordsNode != null && totalRecordsNode.isInt()) {
+        totalRecordsSum += totalRecordsNode.intValue();
+      }
+    }
+
+    response.set(ITEMS, mergedItems);
+    response.put(TOTAL_RECORDS, totalRecordsSum);
+    return response.toString();
+  }
+
+  private List<JsonNode> getItems(InstanceTenants instanceTenants, RequestQueryParameters requestQueryParameters) {
+    var context = (FolioExecutionContext) folioExecutionContext.getInstance();
+    return instanceTenants.tenantIds().parallelStream()
+        .map(tenantId -> context.execute(() -> jsonConverter
+            .readAsTree(inventoryClient.getItems(requestQueryParameters, tenantId))))
+        .toList();
+  }
+
+  private String parseHoldingId(String query) {
+    var matcher = HOLDINGS_ID_PATTERN.matcher(query);
+    if (matcher.find()) {
+      var insideParentheses = matcher.group(1);
+      var ids = insideParentheses.split(" or ");
+      if (ids.length > 0) {
+        return ids[0].trim();
+      }
+    }
+    return null;
+  }
+
+  private String parseInstanceId(String query) {
+    var matcher = INSTANCE_ID_PATTERN.matcher(query);
+    if (matcher.find()) {
+      return matcher.group(2);
+    }
+    return null;
   }
 }

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.client.InventoryClient;
 import org.folio.edge.inventory.client.SearchClient;
 import org.folio.edge.inventory.client.UsersClient;
@@ -28,7 +27,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Log4j2
 public class EcsInventoryService {
 
   public static final String FACET = "holdings.tenantId";

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.client.InventoryClient;
 import org.folio.edge.inventory.client.SearchClient;
 import org.folio.edge.inventory.client.UsersClient;
@@ -31,7 +30,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Log4j2
 public class EcsInventoryService {
 
   public static final String FACET = "holdings.tenantId";

--- a/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
@@ -37,6 +37,8 @@ public class EcsMaterialTypeService {
           UserTenantsUserTenantsInner::getConsortiumId
       ).findFirst();
 
+      log.info("GET ConsortiumId - {}", consortiumId.isPresent());
+
       TenantCollection tenantCollection = consortiumId
           .map(consortiaClient::getTenants)
           .orElseThrow(() -> {

--- a/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
@@ -1,0 +1,68 @@
+package org.folio.edge.inventory.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.edge.inventory.client.ConsortiaClient;
+import org.folio.edge.inventory.client.InventoryClient;
+import org.folio.edge.inventory.client.UsersClient;
+import org.folio.edge.inventory.util.JsonConverter;
+import org.folio.inventory.domain.dto.TenantCollection;
+import org.folio.inventory.domain.dto.UserTenantsUserTenantsInner;
+import org.folio.spring.FolioExecutionContext;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class EcsMaterialTypeService {
+
+  public static final String NAME = "name";
+
+  private final UsersClient usersClient;
+  private final ConsortiaClient consortiaClient;
+  private final InventoryClient inventoryClient;
+  private final JsonConverter jsonConverter;
+  private final FolioExecutionContext folioExecutionContext;
+
+  public String getEcsMaterialTypeById(String materialTypeId) {
+    var userTenants = usersClient.getUserTenants();
+
+    if (userTenants != null) {
+      var consortiumId = userTenants.getUserTenants().stream().map(
+          UserTenantsUserTenantsInner::getConsortiumId
+      ).findFirst();
+
+      TenantCollection tenantCollection = consortiumId
+          .map(consortiaClient::getTenants)
+          .orElseThrow(() -> {
+            log.error("Consortium ID not found in user tenants");
+            return new EntityNotFoundException("Consortium ID not found");
+          });
+
+      var materialTypes = getMaterialTypesFromMemberTenants(tenantCollection, materialTypeId);
+      return materialTypes.stream()
+          .filter(json -> json.has(NAME))
+          .findFirst()
+          .map(JsonNode::toString)
+          .orElseGet(() -> {
+            log.error("Material type not found, returning respective response body");
+            return materialTypes.getFirst().toString();
+          });
+    }
+
+    log.error("User tenants not found");
+    throw new EntityNotFoundException("User tenants not found");
+  }
+
+  private List<JsonNode> getMaterialTypesFromMemberTenants(TenantCollection tenantCollection, String materialTypeId) {
+    var instance = (FolioExecutionContext) folioExecutionContext.getInstance();
+    return tenantCollection.getTenants().stream().map(
+        tenant -> instance.execute(
+            () -> jsonConverter.readAsTree(inventoryClient.getMaterialTypeById(materialTypeId, tenant.getName()))
+        )).toList();
+  }
+
+}

--- a/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 public class EcsMaterialTypeService {
 
   public static final String NAME = "name";
-  public static final String CENTRAL_OFFICE = "Central Office";
 
   private final UsersClient usersClient;
   private final ConsortiaClient consortiaClient;
@@ -70,11 +69,11 @@ public class EcsMaterialTypeService {
 
     return tenantCollection.getTenants().stream()
         .filter(tenant -> {
-          boolean isCentralOffice = CENTRAL_OFFICE.equalsIgnoreCase(tenant.getName());
-          if (isCentralOffice) {
-            log.info("Skipping tenant {} as it is Central Office which is not enabled", tenant.getName());
+          boolean isCentral = Boolean.TRUE.equals(tenant.getIsCentral());
+          if (isCentral) {
+            log.info("Skipping central tenant {} (id: {})", tenant.getName(), tenant.getId());
           }
-          return !isCentralOffice;
+          return !isCentral;
         })
         .map(tenant -> {
           try {

--- a/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
@@ -84,9 +84,8 @@ public class EcsMaterialTypeService {
               return jsonConverter.readAsTree(response);
             });
           } catch (Exception e) {
-            log.error("Failed to retrieve material type {} for tenant {}: {}", materialTypeId, tenant.getName(),
-                e.getMessage());
-            throw new EntityNotFoundException("Failed to retrieve material type for some tenants: {}", e);
+            log.warn("Material type {} not found for tenant {} ({}): {}", materialTypeId, tenant.getName(), tenant.getId(), e.getMessage());
+            return null;
           }
         })
         .filter(Objects::nonNull)

--- a/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
@@ -79,7 +79,7 @@ public class EcsMaterialTypeService {
           try {
             return instance.execute(() -> {
               log.info("Requesting material type {} for tenant {}", materialTypeId, tenant.getName());
-              var response = inventoryClient.getMaterialTypeById(materialTypeId, tenant.getName());
+              var response = inventoryClient.getMaterialTypeById(materialTypeId, tenant.getId());
               return jsonConverter.readAsTree(response);
             });
           } catch (Exception e) {

--- a/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
@@ -30,6 +30,8 @@ public class EcsMaterialTypeService {
   public String getEcsMaterialTypeById(String materialTypeId) {
     var userTenants = usersClient.getUserTenants();
 
+    log.info("usersClient.getUserTenants() - {}", userTenants); //just for debugging
+
     if (userTenants != null) {
       var consortiumId = userTenants.getUserTenants().stream().map(
           UserTenantsUserTenantsInner::getConsortiumId
@@ -41,6 +43,8 @@ public class EcsMaterialTypeService {
             log.error("Consortium ID not found in user tenants");
             return new EntityNotFoundException("Consortium ID not found");
           });
+
+      log.info("tenantCollection - {}", tenantCollection); //just for debugging
 
       var materialTypes = getMaterialTypesFromMemberTenants(tenantCollection, materialTypeId);
       return materialTypes.stream()

--- a/src/main/java/org/folio/edge/inventory/service/InventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/InventoryService.java
@@ -1,14 +1,12 @@
 package org.folio.edge.inventory.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.client.InventoryClient;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Log4j2
 public class InventoryService {
 
   private final InventoryClient inventoryClient;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -12,5 +12,9 @@
         <Logger name="io.swagger.models.parameters.AbstractSerializableParameter" level="error" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
+
+        <Logger name="org.folio.edge.inventory.client.ConsortiaClient" level="debug" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
     </Loggers>
 </Configuration>

--- a/src/main/resources/swagger.api/edge-inventory.yaml
+++ b/src/main/resources/swagger.api/edge-inventory.yaml
@@ -779,6 +779,8 @@ components:
       $ref: './schemas/userTenants.json'
     facetResponse:
       $ref: './schemas/facetResponse.json'
+    holdingResponse:
+      $ref: './schemas/holdingResponse.json'
   parameters:
     request-query-parameters:
       name: requestQueryParameters

--- a/src/main/resources/swagger.api/edge-inventory.yaml
+++ b/src/main/resources/swagger.api/edge-inventory.yaml
@@ -781,6 +781,8 @@ components:
       $ref: './schemas/facetResponse.json'
     holdingResponse:
       $ref: './schemas/holdingResponse.json'
+    tenants:
+      $ref: './schemas/tenantCollection.json'
   parameters:
     request-query-parameters:
       name: requestQueryParameters

--- a/src/main/resources/swagger.api/edge-inventory.yaml
+++ b/src/main/resources/swagger.api/edge-inventory.yaml
@@ -779,6 +779,8 @@ components:
       $ref: './schemas/userTenants.json'
     facetResponse:
       $ref: './schemas/facetResponse.json'
+    tenants:
+      $ref: './schemas/tenantCollection.json'
   parameters:
     request-query-parameters:
       name: requestQueryParameters

--- a/src/main/resources/swagger.api/schemas/holdingResponse.json
+++ b/src/main/resources/swagger.api/schemas/holdingResponse.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Response schema for search holding",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Holdings ID"
+    },
+    "hrid": {
+      "type": "string",
+      "description": "Holdings HRID"
+    },
+    "tenantId": {
+      "type": "string",
+      "description": "Tenant ID of the Holding"
+    },
+    "instanceId": {
+      "type": "string",
+      "description": "Related Instance Id"
+    },
+    "discoverySuppress": {
+      "type": "boolean",
+      "description": "Discovery suppress flag"
+    },
+    "callNumberPrefix": {
+      "type": "string",
+      "description": "Call number prefix"
+    },
+    "callNumber": {
+      "type": "string",
+      "description": "Call number"
+    },
+    "callNumberSuffix": {
+      "type": "string",
+      "description": "Call number suffix"
+    },
+    "copyNumber": {
+      "type": "string",
+      "description": "Copy number"
+    },
+    "permanentLocationId": {
+      "type": "string",
+      "description": "Permanent Location ID"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/main/resources/swagger.api/schemas/tenantCollection.json
+++ b/src/main/resources/swagger.api/schemas/tenantCollection.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Response schema for tenants by consortium Id",
+  "type": "object",
+  "properties": {
+    "tenants": {
+      "description": "Tenants by consortium Id",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 5,
+            "pattern": "^[a-zA-Z0-9]*$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 150
+          },
+          "isCentral": {
+            "type": "boolean"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "code", "name", "isCentral"],
+        "additionalProperties": false
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "tenants",
+    "totalRecords"
+  ],
+  "additionalProperties": false
+}

--- a/src/test/java/org/folio/edge/inventory/TestConstants.java
+++ b/src/test/java/org/folio/edge/inventory/TestConstants.java
@@ -36,6 +36,7 @@ public class TestConstants {
   public static final String SOURCE_RECORD_RESPONSE_PATH ="__files/responses/source-records.json";
   public static final String AUTHORITY_SOURCE_RECORD_RESPONSE_PATH = "__files/responses/authority_source_records.json";
   public static final String HOLDINGS_FACET_RESPONSE_PATH = "__files/responses/holdings_facet_response.json";
+  public static final String HOLDING_RESPONSE_PATH = "__files/responses/holding_response.json";
   public static final String USER_TENANTS_RESPONSE_PATH = "__files/responses/user_tenants_response.json";
   public static final String USER_TENANTS_NON_CONSORTIA_RESPONSE_PATH = "__files/responses/user_tenants_non_consortia_response.json";
   public static final String LOCATIONS_SEARCH_RESPONSE_PATH = "__files/responses/search_locations_response.json";

--- a/src/test/java/org/folio/edge/inventory/controller/EcsInventoryControllerIT.java
+++ b/src/test/java/org/folio/edge/inventory/controller/EcsInventoryControllerIT.java
@@ -2,7 +2,9 @@ package org.folio.edge.inventory.controller;
 
 import static org.folio.edge.inventory.TestConstants.CAMPUS_ID;
 import static org.folio.edge.inventory.TestConstants.GET_CAMPUS_BY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_HOLDINGS_URL;
 import static org.folio.edge.inventory.TestConstants.GET_INSTITUTION_BY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_ITEMS_URL;
 import static org.folio.edge.inventory.TestConstants.GET_LIBRARY_BY_ID_URL;
 import static org.folio.edge.inventory.TestConstants.GET_LOCATION_BY_ID_URL;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_URL;
@@ -15,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.folio.edge.inventory.BaseIntegrationTests;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -39,6 +42,60 @@ class EcsInventoryControllerIT extends BaseIntegrationTests {
         .andExpect(jsonPath("instances[1].isBoundWith", is(false)))
         .andExpect(jsonPath("instances[1].items", hasSize(1)))
         .andExpect(jsonPath("instances[1].holdingsRecords", hasSize(1)))
+        .andExpect(jsonPath("totalRecords", is(2)));
+  }
+
+  @Test
+  void getInventoryHoldings_shouldReturnInventoryHoldingsFromMemberTenant() throws Exception {
+    doGetWithParams(mockMvc, GET_HOLDINGS_URL, "query",
+        "instanceId==d41d9172-1869-11eb-adc1-0242ac120002%20not%20discoverySuppress==true", true).andExpect(status().isOk())
+        .andExpect(jsonPath("holdingsRecords[0].instanceId", is("a89eccf0-57a6-495e-898d-32b9b2210f2f")))
+        .andExpect(jsonPath("holdingsRecords[0].id", is("67cd0046-e4f1-4e4f-9024-adf0b0039d09")))
+        .andExpect(jsonPath("holdingsRecords[1].instanceId", is("e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6")))
+        .andExpect(jsonPath("holdingsRecords[1].id", is("e9285a1c-1dfc-4380-868c-e74073003f43")))
+        .andExpect(jsonPath("holdingsRecords[2].instanceId", is("a89eccf0-57a6-495e-898d-32b9b2210f2f")))
+        .andExpect(jsonPath("holdingsRecords[2].id", is("67cd0046-e4f1-4e4f-9024-adf0b0039d09")))
+        .andExpect(jsonPath("holdingsRecords[3].instanceId", is("e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6")))
+        .andExpect(jsonPath("holdingsRecords[3].id", is("e9285a1c-1dfc-4380-868c-e74073003f43")))
+        .andExpect(jsonPath("totalRecords", is(4)));
+  }
+
+  @Test
+  void getInventoryHoldings_shouldReturnEmptyResponse() throws Exception {
+    doGetWithParams(mockMvc, GET_HOLDINGS_URL, "query",
+        "instanceId==31fcc8e7-a019-43f4-b642-2edc389f4501%20not%20discoverySuppress==true", true).andExpect(status().isOk())
+        .andExpect(jsonPath("holdingsRecords", Matchers.hasSize(0)))
+        .andExpect(jsonPath("totalRecords", is(0)));
+  }
+
+  @Test
+  void getInventoryItems_shouldReturnInventoryHoldingsFromMemberTenant_whenQueryWithInstanceId() throws Exception {
+    doGetWithParams(mockMvc, GET_ITEMS_URL, "query",
+        "instance.id==d41d9172-1869-11eb-adc1-0242ac120002", true).andExpect(status().isOk())
+        .andExpect(jsonPath("items[0].holdingsRecordId", is("e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")))
+        .andExpect(jsonPath("items[0].id", is("7212ba6a-8dcf-45a1-be9a-ffaa847c4423")))
+        .andExpect(jsonPath("items[1].holdingsRecordId", is("e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")))
+        .andExpect(jsonPath("items[1].id", is("7212ba6a-8dcf-45a1-be9a-ffaa847c4423")))
+        .andExpect(jsonPath("totalRecords", is(2)));
+  }
+
+  @Test
+  void getInventoryItems_shouldReturnEmpty() throws Exception {
+    doGetWithParams(mockMvc, GET_ITEMS_URL, "query",
+        "instance.id==31fcc8e7-a019-43f4-b642-2edc389f4501", true).andExpect(status().isOk())
+        .andExpect(jsonPath("items", hasSize(0)))
+        .andExpect(jsonPath("totalRecords", is(0)));
+  }
+
+  @Test
+  void getInventoryItems_shouldReturnInventoryHoldingsFromMemberTenant_whenQueryWithHoldingsRecordId() throws Exception {
+    doGetWithParams(mockMvc, GET_ITEMS_URL, "query",
+        "cql.allRecords=1%20NOT%20discoverySuppress==true%20and%20holdingsRecordId==(e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19)",
+        true).andExpect(status().isOk())
+        .andExpect(jsonPath("items[0].holdingsRecordId", is("e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")))
+        .andExpect(jsonPath("items[0].id", is("7212ba6a-8dcf-45a1-be9a-ffaa847c4423")))
+        .andExpect(jsonPath("items[1].holdingsRecordId", is("e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")))
+        .andExpect(jsonPath("items[1].id", is("7212ba6a-8dcf-45a1-be9a-ffaa847c4423")))
         .andExpect(jsonPath("totalRecords", is(2)));
   }
 

--- a/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
@@ -4,11 +4,15 @@ import static org.folio.edge.inventory.TestConstants.CENTRAL_TEST_TENANT;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_WITHOUT_HOLDINGS_PATH;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_WITH_HOLDINGS_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDINGS_FACET_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.HOLDINGS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.HOLDING_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.ITEMS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.USER_TENANTS_NON_CONSORTIA_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.USER_TENANTS_RESPONSE_PATH;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.HOLDINGS_RECORDS;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.INSTANCES;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.ITEMS;
+import static org.folio.edge.inventory.models.InventoryViewJsonFields.TOTAL_RECORDS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +27,7 @@ import org.folio.edge.inventory.client.SearchClient;
 import org.folio.edge.inventory.client.UsersClient;
 import org.folio.edge.inventory.util.JsonConverter;
 import org.folio.inventory.domain.dto.FacetResponse;
+import org.folio.inventory.domain.dto.HoldingResponse;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.folio.inventory.domain.dto.UserTenants;
 import org.folio.spring.FolioExecutionContext;
@@ -74,6 +79,63 @@ public class EcsInventoryServiceTest {
     assertTrue(response.findValue(INSTANCES).get(0).has(ITEMS));
     assertTrue(response.findValue(INSTANCES).get(1).has(HOLDINGS_RECORDS));
     assertTrue(response.findValue(INSTANCES).get(1).has(ITEMS));
+  }
+
+  @Test
+  void getEcsInventoryHoldings_shouldReturnInventoryHoldingsFromMemberTenant() throws JsonProcessingException {
+    var request = new RequestQueryParameters();
+    request.setQuery("instanceId==d41d9172-1869-11eb-adc1-0242ac120002%20not%20discoverySuppress==true");
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(folioExecutionContext.execute(any())).thenCallRealMethod();
+    var facetResponse = objectMapper.readValue(TestUtil.readFileContentFromResources(HOLDINGS_FACET_RESPONSE_PATH),
+        FacetResponse.class);
+    when(searchClient.getInstanceFacet(Mockito.eq(ecsInventoryService.FACET), Mockito.anyString()))
+        .thenReturn(facetResponse);
+    when(inventoryClient.getHoldings(Mockito.any(), Mockito.eq(TestConstants.TEST_TENANT)))
+        .thenReturn(TestUtil.readFileContentFromResources(HOLDINGS_RESPONSE_PATH));
+
+    var response = jsonConverter.readAsTree(ecsInventoryService.getEcsInventoryHoldings(request));
+    assertTrue(response.has(HOLDINGS_RECORDS));
+    assertTrue(response.has(TOTAL_RECORDS));
+  }
+
+  @Test
+  void getEcsInventoryItems_shouldReturnInventoryHoldingsFromMemberTenant_queryWithInstanceId() throws JsonProcessingException {
+    var request = new RequestQueryParameters();
+    request.setQuery("instance.id==d41d9172-1869-11eb-adc1-0242ac120002");
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(folioExecutionContext.execute(any())).thenCallRealMethod();
+    var facetResponse = objectMapper.readValue(TestUtil.readFileContentFromResources(HOLDINGS_FACET_RESPONSE_PATH),
+        FacetResponse.class);
+    when(searchClient.getInstanceFacet(Mockito.eq(ecsInventoryService.FACET), Mockito.anyString()))
+        .thenReturn(facetResponse);
+    when(inventoryClient.getItems(Mockito.any(), Mockito.eq(TestConstants.TEST_TENANT)))
+        .thenReturn(TestUtil.readFileContentFromResources(ITEMS_RESPONSE_PATH));
+
+    var response = jsonConverter.readAsTree(ecsInventoryService.getEcsInventoryItems(request));
+    assertTrue(response.has(ITEMS));
+    assertTrue(response.has(TOTAL_RECORDS));
+  }
+
+  @Test
+  void getEcsInventoryItems_shouldReturnInventoryHoldingsFromMemberTenant_queryWithHoldingsRecordId() throws JsonProcessingException {
+    var request = new RequestQueryParameters();
+    request.setQuery("cql.allRecords=1%20NOT%20discoverySuppress==true%20and%20holdingsRecordId==(e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19)");
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(folioExecutionContext.execute(any())).thenCallRealMethod();
+    var holdingResponse = objectMapper.readValue(TestUtil.readFileContentFromResources(HOLDING_RESPONSE_PATH),
+        HoldingResponse.class);
+    when(searchClient.getConsortiumHolding(Mockito.any())).thenReturn(holdingResponse);
+    var facetResponse = objectMapper.readValue(TestUtil.readFileContentFromResources(HOLDINGS_FACET_RESPONSE_PATH),
+        FacetResponse.class);
+    when(searchClient.getInstanceFacet(Mockito.eq(ecsInventoryService.FACET), Mockito.anyString()))
+        .thenReturn(facetResponse);
+    when(inventoryClient.getItems(Mockito.any(), Mockito.eq(TestConstants.TEST_TENANT)))
+        .thenReturn(TestUtil.readFileContentFromResources(ITEMS_RESPONSE_PATH));
+
+    var response = jsonConverter.readAsTree(ecsInventoryService.getEcsInventoryItems(request));
+    assertTrue(response.has(ITEMS));
+    assertTrue(response.has(TOTAL_RECORDS));
   }
 
   @Test

--- a/src/test/resources/__files/responses/holding_response.json
+++ b/src/test/resources/__files/responses/holding_response.json
@@ -1,0 +1,8 @@
+{
+  "id": "7e46a426-83c9-44f8-9cb1-5d6e578fc57c",
+  "hrid": "test10000205421",
+  "tenantId": "test",
+  "instanceId": "d41d9172-1869-11eb-adc1-0242ac120002",
+  "discoverySuppress": false,
+  "permanentLocationId": "53cf956f-c1df-410b-8bea-27f712cca7c0"
+}

--- a/src/test/resources/__files/responses/holdings_facet_with_two_tenants_response.json
+++ b/src/test/resources/__files/responses/holdings_facet_with_two_tenants_response.json
@@ -1,0 +1,18 @@
+{
+  "facets": {
+    "holdings.tenantId": {
+      "values": [
+        {
+          "id": "test1",
+          "totalRecords": 1
+        },
+        {
+          "id": "test2",
+          "totalRecords": 1
+        }
+      ],
+      "totalRecords": 1
+    }
+  },
+  "totalRecords": 1
+}

--- a/src/test/resources/mappings/ecs_inventory_view.json
+++ b/src/test/resources/mappings/ecs_inventory_view.json
@@ -51,6 +51,208 @@
           "Content-Type": "application/json"
         }
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/holdings-storage/holdings",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test1"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "d41d9172-1869-11eb-adc1-0242ac120002"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/holdings_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/holdings-storage/holdings",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test2"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "d41d9172-1869-11eb-adc1-0242ac120002"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/holdings_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/holdings-storage/holdings",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "31fcc8e7-a019-43f4-b642-2edc389f4501"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": "{}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/inventory/items",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "31fcc8e7-a019-43f4-b642-2edc389f4501"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": "{}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/inventory/items",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test1"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "d41d9172-1869-11eb-adc1-0242ac120002"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/items_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/inventory/items",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test2"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "d41d9172-1869-11eb-adc1-0242ac120002"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/items_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/search/consortium/holding/e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "central_test"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/holding_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/inventory/items",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test1"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/items_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/inventory/items",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test2"
+          }
+        },
+        "queryParameters": {
+          "query": {
+            "contains": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/items_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
     }
   ]
 }

--- a/src/test/resources/mappings/holdings_facet.json
+++ b/src/test/resources/mappings/holdings_facet.json
@@ -3,7 +3,48 @@
     {
       "request": {
         "method": "GET",
-        "urlPath": "/search/instances/facets"
+        "urlPath": "/search/instances/facets",
+        "queryParameters": {
+          "query": {
+            "contains": "d41d9172-1869-11eb-adc1-0242ac120002"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/holdings_facet_with_two_tenants_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/search/instances/facets",
+        "queryParameters": {
+          "query": {
+            "contains": "f1e82a1e-fc06-4b82-bb1d-da326cb378ce"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/holdings_facet_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/search/instances/facets",
+        "queryParameters": {
+          "query": {
+            "contains": "31fcc8e7-a019-43f4-b642-2edc389f4501"
+          }
+        }
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
## Approach
https://folio-org.atlassian.net/browse/EDGEINV-14?atlOrigin=eyJpIjoiMDM3Nzc2MThmMzZkNDhjYTg1ZWVmYTg4MDNmZDhjYTgiLCJwIjoiaiJ9
- We need to update edge-inventory GET /inventory/material-types/{id} endpoint to retrieve consolidated items material types across all member tenants. 
- We need these changes to map source type correctly during batch-enrichment for a LoC central tenant.

## Checklist
<!--
  This serves as gentle reminder for common tasks. Confirm these are done and check all that apply.
-->
- [ ] Documentation updated
- [x] Tests cover new or modified code
- [ ] New dependencies added
- [ ] Includes breaking changes
- [ ] Module permissions been updated when calling new APIs
- [ ] The interface version has been bumped
- [ ] Coordinated corresponding changes in the UI and other backend modules that consume new interface 

## Result
