### PR TITLE
EDGEINV-14: Update GET /inventory/material-types/{id} endpoint to retrieve consolidated material types across all tenants

### DIFF
--- a/src/main/java/org/folio/edge/inventory/client/ConsortiaClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/ConsortiaClient.java
@@ -1,0 +1,15 @@
+package org.folio.edge.inventory.client;
+
+import org.folio.edge.inventory.config.InventoryClientConfig;
+import org.folio.inventory.domain.dto.TenantCollection;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "consortia", configuration = InventoryClientConfig.class)
+public interface ConsortiaClient {
+
+  @GetMapping(value = "/consortia/{consortiumId}/tenants", consumes = MediaType.APPLICATION_JSON_VALUE)
+  TenantCollection getTenants(@PathVariable String consortiumId);
+}

--- a/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
@@ -23,7 +23,8 @@ public interface InventoryClient {
   String getHoldings(@SpringQueryMap Object requestQueryParameters);
 
   @GetMapping(value = "/holdings-storage/holdings", consumes = MediaType.APPLICATION_JSON_VALUE)
-  String getHoldings(@SpringQueryMap Object requestQueryParameters, @RequestHeader(XOkapiHeaders.TENANT) String tenantId);
+  String getHoldings(@SpringQueryMap Object requestQueryParameters,
+      @RequestHeader(XOkapiHeaders.TENANT) String tenantId);
 
   @GetMapping(value = "/identifier-types", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getIdentifierTypes(@SpringQueryMap Object requestQueryParameters);
@@ -77,7 +78,8 @@ public interface InventoryClient {
   String getInstanceNoteTypes(@SpringQueryMap Object requestQueryParameters);
 
   @GetMapping(value = "/inventory-view/instances", consumes = MediaType.APPLICATION_JSON_VALUE)
-  String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters, @RequestParam Boolean withBoundedItems);
+  String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters,
+      @RequestParam Boolean withBoundedItems);
 
   @GetMapping(value = "/inventory-view/instances", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getInventoryViewInstances(@SpringQueryMap Object requestQueryParameters,
@@ -88,6 +90,10 @@ public interface InventoryClient {
 
   @GetMapping(value = "/material-types/{materialTypeId}", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getMaterialTypeById(@PathVariable("materialTypeId") String materialTypeId);
+
+  @GetMapping(value = "/material-types/{materialTypeId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getMaterialTypeById(@PathVariable("materialTypeId") String materialTypeId,
+      @RequestHeader(XOkapiHeaders.TENANT) String tenantId);
 
   @GetMapping(value = "/source-storage/records/{instanceId}/formatted?idType=INSTANCE", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getSourceRecords(@PathVariable("instanceId") String instanceId);

--- a/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
+++ b/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
@@ -6,6 +6,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.service.DataExportService;
 import org.folio.edge.inventory.service.EcsInventoryService;
 import org.folio.edge.inventory.service.EcsLocationsService;
+import org.folio.edge.inventory.service.EcsMaterialTypeService;
 import org.folio.edge.inventory.service.InventoryService;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.folio.inventory.rest.resource.InventoryApi;
@@ -23,6 +24,7 @@ public class InventoryController implements InventoryApi {
   private final DataExportService dataExportService;
   private final EcsInventoryService ecsInventoryService;
   private final EcsLocationsService ecsLocationsService;
+  private final EcsMaterialTypeService materialTypeService;
 
   @Override
   public ResponseEntity<String> getInstance(String instanceId, String xOkapiTenant, String xOkapiToken, String lang) {
@@ -174,7 +176,8 @@ public class InventoryController implements InventoryApi {
       RequestQueryParameters requestQueryParameters, Boolean withBoundedItems) {
     log.info("Retrieving inventory view instances by query {}", requestQueryParameters.getQuery());
     if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
-      return ResponseEntity.ok(ecsInventoryService.getEcsInventoryViewInstances(requestQueryParameters, withBoundedItems));
+      return ResponseEntity.ok(
+          ecsInventoryService.getEcsInventoryViewInstances(requestQueryParameters, withBoundedItems));
     }
     return ResponseEntity.ok(inventoryService.getInventoryViewInstances(requestQueryParameters, withBoundedItems));
   }
@@ -182,6 +185,10 @@ public class InventoryController implements InventoryApi {
   @Override
   public ResponseEntity<String> getMaterialTypeById(String materialTypeId, String xOkapiTenant, String xOkapiToken) {
     log.info("Retrieving material type by id {}", materialTypeId);
+    if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
+      return ResponseEntity.ok(
+          materialTypeService.getEcsMaterialTypeById(materialTypeId));
+    }
     return ResponseEntity.ok(inventoryService.getMaterialTypeById(materialTypeId));
   }
 

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.client.InventoryClient;
 import org.folio.edge.inventory.client.SearchClient;
 import org.folio.edge.inventory.client.UsersClient;
@@ -31,7 +30,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Log4j2
 public class EcsInventoryService {
 
   public static final String FACET = "holdings.tenantId";

--- a/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsMaterialTypeService.java
@@ -1,0 +1,88 @@
+package org.folio.edge.inventory.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.edge.inventory.client.ConsortiaClient;
+import org.folio.edge.inventory.client.InventoryClient;
+import org.folio.edge.inventory.client.UsersClient;
+import org.folio.edge.inventory.util.JsonConverter;
+import org.folio.inventory.domain.dto.TenantCollection;
+import org.folio.inventory.domain.dto.UserTenantsUserTenantsInner;
+import org.folio.spring.FolioExecutionContext;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class EcsMaterialTypeService {
+
+  public static final String NAME = "name";
+  public static final String SECURE_TENANT_CODE = "SEC";
+
+  private final UsersClient usersClient;
+  private final ConsortiaClient consortiaClient;
+  private final InventoryClient inventoryClient;
+  private final JsonConverter jsonConverter;
+  private final FolioExecutionContext folioExecutionContext;
+
+  public String getEcsMaterialTypeById(String materialTypeId) {
+    var userTenants = usersClient.getUserTenants();
+
+    if (userTenants != null) {
+      var consortiumId = userTenants.getUserTenants().stream().map(
+          UserTenantsUserTenantsInner::getConsortiumId
+      ).findFirst();
+
+      TenantCollection tenantCollection = consortiumId
+          .map(consortiaClient::getTenants)
+          .orElseThrow(() -> {
+            log.error("Consortium ID not found in user tenants");
+            return new EntityNotFoundException("Consortium ID not found");
+          });
+
+      var materialTypes = getMaterialTypesFromMemberTenants(tenantCollection, materialTypeId);
+      return materialTypes.stream()
+          .filter(json -> json.has(NAME))
+          .findFirst()
+          .map(JsonNode::toString)
+          .orElseGet(() -> {
+            log.error("Material type not found, returning respective response body");
+            return materialTypes.getFirst().toString();
+          });
+    }
+
+    log.error("User tenants not found");
+    throw new EntityNotFoundException("User tenants not found");
+  }
+
+  private List<JsonNode> getMaterialTypesFromMemberTenants(TenantCollection tenantCollection, String materialTypeId) {
+    var instance = (FolioExecutionContext) folioExecutionContext.getInstance();
+
+    return tenantCollection.getTenants().stream()
+        .filter(tenant -> {
+          boolean isSecTenant = SECURE_TENANT_CODE.equalsIgnoreCase(tenant.getCode());
+          if (isSecTenant) {
+            log.info("Skipping tenant with name: {} and id: {}", tenant.getName(), tenant.getId());
+          }
+          return !isSecTenant;
+        })
+        .map(tenant -> {
+          try {
+            return instance.execute(() -> {
+              log.info("Requesting material type {} for tenant {}", materialTypeId, tenant.getName());
+              var response = inventoryClient.getMaterialTypeById(materialTypeId, tenant.getId());
+              return jsonConverter.readAsTree(response);
+            });
+          } catch (Exception e) {
+            log.warn("Material type {} not found for tenant {}: {}", materialTypeId, tenant.getName(), e.getMessage());
+            return null;
+          }
+        })
+        .filter(Objects::nonNull)
+        .toList();
+  }
+}

--- a/src/main/java/org/folio/edge/inventory/service/InventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/InventoryService.java
@@ -1,14 +1,12 @@
 package org.folio.edge.inventory.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.folio.edge.inventory.client.InventoryClient;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Log4j2
 public class InventoryService {
 
   private final InventoryClient inventoryClient;

--- a/src/main/resources/swagger.api/edge-inventory.yaml
+++ b/src/main/resources/swagger.api/edge-inventory.yaml
@@ -781,13 +781,15 @@ components:
       $ref: './schemas/facetResponse.json'
     holdingResponse:
       $ref: './schemas/holdingResponse.json'
+    tenants:
+      $ref: './schemas/tenantCollection.json'
   parameters:
     request-query-parameters:
       name: requestQueryParameters
       in: query
       description: Request query parameters(query, limit, offset and etc.) as object.
       schema:
-        $ref: '#/components/schemas/requestQueryParameters'    
+        $ref: '#/components/schemas/requestQueryParameters'
     x-okapi-tenant-header:
       name: x-okapi-tenant
       in: header

--- a/src/main/resources/swagger.api/schemas/tenantCollection.json
+++ b/src/main/resources/swagger.api/schemas/tenantCollection.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Response schema for tenants by consortium Id",
+  "type": "object",
+  "properties": {
+    "tenants": {
+      "description": "Tenants by consortium Id",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 5,
+            "pattern": "^[a-zA-Z0-9]*$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 150
+          },
+          "isCentral": {
+            "type": "boolean"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "code", "name", "isCentral"],
+        "additionalProperties": false
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "tenants",
+    "totalRecords"
+  ],
+  "additionalProperties": false
+}

--- a/src/test/java/org/folio/edge/inventory/TestConstants.java
+++ b/src/test/java/org/folio/edge/inventory/TestConstants.java
@@ -33,12 +33,14 @@ public class TestConstants {
   public static final String CAMPUS_BY_ID_PATH ="__files/responses/campus_by_id_response.json";
   public static final String LIBRARY_BY_ID_PATH ="__files/responses/library_by_id_response.json";
   public static final String MATERIAL_TYPE_BY_ID_PATH ="__files/responses/material_type_by_id_response.json";
+  public static final String MATERIAL_TYPE_OF_MEMBER_FROM_CENTRAL_TENANT_PATH ="__files/responses/material_type_of_member_from_central_tenant_response.json";
   public static final String SOURCE_RECORD_RESPONSE_PATH ="__files/responses/source-records.json";
   public static final String AUTHORITY_SOURCE_RECORD_RESPONSE_PATH = "__files/responses/authority_source_records.json";
   public static final String HOLDINGS_FACET_RESPONSE_PATH = "__files/responses/holdings_facet_response.json";
   public static final String HOLDING_RESPONSE_PATH = "__files/responses/holding_response.json";
   public static final String USER_TENANTS_RESPONSE_PATH = "__files/responses/user_tenants_response.json";
   public static final String USER_TENANTS_NON_CONSORTIA_RESPONSE_PATH = "__files/responses/user_tenants_non_consortia_response.json";
+  public static final String CONSORTIA_TENANTS_RESPONSE_PATH = "__files/responses/consortia_tenants_response.json";
   public static final String LOCATIONS_SEARCH_RESPONSE_PATH = "__files/responses/search_locations_response.json";
   public static final String INSTITUTIONS_SEARCH_RESPONSE_PATH = "__files/responses/search_institutions_response.json";
   public static final String CAMPUSES_SEARCH_RESPONSE_PATH = "__files/responses/search_campuses_response.json";
@@ -81,6 +83,7 @@ public class TestConstants {
   public static final String GET_ALTERNATIVE_TITLE_TYPES_URL = "/inventory/alternative-title-types";
   public static final String GET_SUBJECT_SOURCES_URL = "/inventory/subject-sources";
   public static final String GET_SUBJECT_TYPES_URL = "/inventory/subject-types";
+  public static final String GET_MATERIAL_TYPES_URL = "/inventory/material-types/40db37f8-2500-402c-bfd1-8b4764e738d0";
   public static final String INSTITUTION_ID = "6ecd8132-caef-4f87-bbb0-9fc07d71357d";
   public static final String LIBRARY_ID = "5d78803e-ca04-4b4a-aeae-2c63b924518b";
   public static final String CAMPUS_ID = "62cf76b7-cca5-4d33-9217-edf42ce1a848";

--- a/src/test/java/org/folio/edge/inventory/controller/EcsInventoryControllerIT.java
+++ b/src/test/java/org/folio/edge/inventory/controller/EcsInventoryControllerIT.java
@@ -7,6 +7,7 @@ import static org.folio.edge.inventory.TestConstants.GET_INSTITUTION_BY_ID_URL;
 import static org.folio.edge.inventory.TestConstants.GET_ITEMS_URL;
 import static org.folio.edge.inventory.TestConstants.GET_LIBRARY_BY_ID_URL;
 import static org.folio.edge.inventory.TestConstants.GET_LOCATION_BY_ID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_MATERIAL_TYPES_URL;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_URL;
 import static org.folio.edge.inventory.TestConstants.INSTITUTION_ID;
 import static org.folio.edge.inventory.TestConstants.LIBRARY_ID;
@@ -133,6 +134,15 @@ class EcsInventoryControllerIT extends BaseIntegrationTests {
         .andExpect(jsonPath("id", is(LIBRARY_ID)))
         .andExpect(jsonPath("name", is("Annex")))
         .andExpect(jsonPath("code", is("KU/CC/DI/A")));
+  }
+
+  @Test
+  void getMaterialTypeById_shouldReturnMaterialTypeWhenCentral() throws Exception {
+    doGet(mockMvc, GET_MATERIAL_TYPES_URL, true)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("id", is("79a28446-25ed-4be6-8821-20b57cae0677")))
+        .andExpect(jsonPath("name", is("test for member from central")))
+        .andExpect(jsonPath("source", is("local")));
   }
 
 

--- a/src/test/java/org/folio/edge/inventory/service/EcsMaterialTypeServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsMaterialTypeServiceTest.java
@@ -1,0 +1,75 @@
+package org.folio.edge.inventory.service;
+
+import static org.folio.edge.inventory.TestConstants.CENTRAL_TEST_TENANT;
+import static org.folio.edge.inventory.TestConstants.CONSORTIA_TENANTS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.MATERIAL_TYPE_ID;
+import static org.folio.edge.inventory.TestConstants.MATERIAL_TYPE_OF_MEMBER_FROM_CENTRAL_TENANT_PATH;
+import static org.folio.edge.inventory.TestConstants.USER_TENANTS_RESPONSE_PATH;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.folio.edge.inventory.TestUtil;
+import org.folio.edge.inventory.client.ConsortiaClient;
+import org.folio.edge.inventory.client.InventoryClient;
+import org.folio.edge.inventory.client.UsersClient;
+import org.folio.edge.inventory.util.JsonConverter;
+import org.folio.inventory.domain.dto.TenantCollection;
+import org.folio.inventory.domain.dto.UserTenants;
+import org.folio.spring.FolioExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EcsMaterialTypeServiceTest {
+
+  @Mock
+  private ConsortiaClient consortiaClient;
+  @Mock
+  private UsersClient usersClient;
+  @Mock
+  private InventoryClient inventoryClient;
+  @Mock
+  private FolioExecutionContext folioExecutionContext;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final JsonConverter jsonConverter = new JsonConverter(objectMapper);
+  private EcsMaterialTypeService ecsMaterialTypeService;
+
+  @BeforeEach
+  void setUp() {
+    ecsMaterialTypeService = new EcsMaterialTypeService(usersClient, consortiaClient, inventoryClient, jsonConverter,
+        folioExecutionContext);
+  }
+
+  @Test
+  void getEcsMaterialTypeById_shouldReturnMaterialTypeFromMemberTenant()
+      throws JsonProcessingException {
+    var userTenants = objectMapper.readValue(TestUtil.readFileContentFromResources(USER_TENANTS_RESPONSE_PATH),
+        UserTenants.class);
+    var consortiaTenants = objectMapper.readValue(
+        TestUtil.readFileContentFromResources(CONSORTIA_TENANTS_RESPONSE_PATH), TenantCollection.class);
+    var expectedMaterialTypeResponse = TestUtil.readFileContentFromResources(
+        MATERIAL_TYPE_OF_MEMBER_FROM_CENTRAL_TENANT_PATH);
+
+    when(usersClient.getUserTenants()).thenReturn(userTenants);
+    when(consortiaClient.getTenants(any())).thenReturn(consortiaTenants);
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(folioExecutionContext.execute(any())).thenCallRealMethod();
+    when(inventoryClient.getMaterialTypeById(MATERIAL_TYPE_ID, CENTRAL_TEST_TENANT)).thenReturn(
+        expectedMaterialTypeResponse);
+
+    var materialTypeJson = jsonConverter.readAsTree(ecsMaterialTypeService.getEcsMaterialTypeById(MATERIAL_TYPE_ID));
+
+    assertTrue(materialTypeJson.hasNonNull("id"));
+    assertTrue(materialTypeJson.hasNonNull("name"));
+    assertTrue(materialTypeJson.hasNonNull("source"));
+  }
+
+
+}

--- a/src/test/resources/__files/responses/consortia_tenants_response.json
+++ b/src/test/resources/__files/responses/consortia_tenants_response.json
@@ -1,0 +1,26 @@
+{
+  "tenants": [
+    {
+      "id": "central_test",
+      "code": "CEN",
+      "name": "Central Office",
+      "isCentral": true,
+      "isDeleted": false
+    },
+    {
+      "id": "cs00000int_0001",
+      "code": "COL",
+      "name": "College",
+      "isCentral": false,
+      "isDeleted": false
+    },
+    {
+      "id": "cs00000int_0013",
+      "code": "SEC",
+      "name": "Secure tenant",
+      "isCentral": false,
+      "isDeleted": false
+    }
+  ],
+  "totalRecords": 13
+}

--- a/src/test/resources/__files/responses/material_type_of_member_from_central_tenant_response.json
+++ b/src/test/resources/__files/responses/material_type_of_member_from_central_tenant_response.json
@@ -1,0 +1,11 @@
+{
+  "id" : "79a28446-25ed-4be6-8821-20b57cae0677",
+  "name" : "test for member from central",
+  "source" : "local",
+  "metadata" : {
+    "createdDate" : "2025-04-17T13:58:59.224+00:00",
+    "createdByUserId" : "da39f5a8-dac0-4e6e-8731-865c133ad187",
+    "updatedDate" : "2025-04-17T13:58:59.224+00:00",
+    "updatedByUserId" : "da39f5a8-dac0-4e6e-8731-865c133ad187"
+  }
+}

--- a/src/test/resources/mappings/ecs_material_type.json
+++ b/src/test/resources/mappings/ecs_material_type.json
@@ -1,0 +1,40 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/material-types/40db37f8-2500-402c-bfd1-8b4764e738d0",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "central_test"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/material_type_of_member_from_central_tenant_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/consortia/1f06c60e-4431-432d-97a4-ca2bc6b152cb/tenants",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "central_test"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/consortia_tenants_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Approach
https://folio-org.atlassian.net/browse/EDGEINV-14

- We need to update edge-inventory GET /inventory/material-types/{id} endpoint to retrieve consolidated items material types across all member tenants. 
- We need these changes to map source type correctly during batch-enrichment for a LoC central tenant.

## Checklist
<!--
  This serves as gentle reminder for common tasks. Confirm these are done and check all that apply.
-->
- [ ] Documentation updated
- [x] Tests cover new or modified code
- [ ] New dependencies added
- [ ] Includes breaking changes
- [ ] Module permissions been updated when calling new APIs
- [ ] The interface version has been bumped
- [ ] Coordinated corresponding changes in the UI and other backend modules that consume new interface 

## Result
<img width="861" alt="image" src="https://github.com/user-attachments/assets/f85474ca-c42c-4796-95ba-70f51afb4004" />
