### PR TITLE
EDGEINV-27. Implement GET /material-types collection endpoint in edge-inventory

### DIFF
--- a/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
@@ -88,6 +88,9 @@ public interface InventoryClient {
   @GetMapping(value = "/alternative-title-types", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getAlternativeTitleTypes(@SpringQueryMap Object requestQueryParameters);
 
+  @GetMapping(value = "/material-types", consumes = MediaType.APPLICATION_JSON_VALUE)
+  String getMaterialTypes(@SpringQueryMap Object requestQueryParameters);
+
   @GetMapping(value = "/material-types/{materialTypeId}", consumes = MediaType.APPLICATION_JSON_VALUE)
   String getMaterialTypeById(@PathVariable("materialTypeId") String materialTypeId);
 

--- a/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
+++ b/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
@@ -183,6 +183,13 @@ public class InventoryController implements InventoryApi {
   }
 
   @Override
+  public ResponseEntity<String> getMaterialTypes(String xOkapiTenant, String xOkapiToken,
+      RequestQueryParameters requestQueryParameters) {
+    log.info("Retrieving material types by query {}", requestQueryParameters.getQuery());
+    return ResponseEntity.ok(inventoryService.getMaterialTypes(requestQueryParameters));
+  }
+
+  @Override
   public ResponseEntity<String> getMaterialTypeById(String materialTypeId, String xOkapiTenant, String xOkapiToken) {
     log.info("Retrieving material type by id {}", materialTypeId);
     if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {

--- a/src/main/java/org/folio/edge/inventory/service/InventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/InventoryService.java
@@ -95,6 +95,10 @@ public class InventoryService {
     return inventoryClient.getInventoryViewInstances(requestQueryParameters, withBoundedItems);
   }
 
+  public String getMaterialTypes(RequestQueryParameters requestQueryParameters) {
+    return inventoryClient.getMaterialTypes(requestQueryParameters);
+  }
+
   public String getMaterialTypeById(String materialTypeId) {
     return inventoryClient.getMaterialTypeById(materialTypeId);
   }

--- a/src/main/resources/swagger.api/edge-inventory.yaml
+++ b/src/main/resources/swagger.api/edge-inventory.yaml
@@ -608,6 +608,31 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
 
+  /inventory/material-types:
+    get:
+      tags:
+        - materialTypes
+      operationId: getMaterialTypes
+      summary: Retrieve collection of material type items.
+      description: Retrieve collection of material type items.
+      parameters:
+        - $ref: '#/components/parameters/x-okapi-tenant-header'
+        - $ref: '#/components/parameters/x-okapi-token-header'
+        - $ref: '#/components/parameters/request-query-parameters'
+      responses:
+        '200':
+          description: |
+            Calls the mod-inventory-storage GET /material-types API and returns the result as-is. \
+            The example of response: https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/examples/materialtypes.json
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
+
   /inventory/material-types/{materialTypeId}:
     get:
       tags:
@@ -1015,6 +1040,7 @@ tags:
   - name: instanceTypes
   - name: inventoryViewInstances
   - name: alternativeTitleTypes
+  - name: materialTypes
   - name: library
   - name: sourceRecords
   - name: authoritySourceRecords

--- a/src/test/java/org/folio/edge/inventory/TestConstants.java
+++ b/src/test/java/org/folio/edge/inventory/TestConstants.java
@@ -32,6 +32,7 @@ public class TestConstants {
   public static final String INSTITUTION_BY_ID_PATH ="__files/responses/institution_by_id_response.json";
   public static final String CAMPUS_BY_ID_PATH ="__files/responses/campus_by_id_response.json";
   public static final String LIBRARY_BY_ID_PATH ="__files/responses/library_by_id_response.json";
+  public static final String MATERIAL_TYPES_RESPONSE_PATH ="__files/responses/material_types_response.json";
   public static final String MATERIAL_TYPE_BY_ID_PATH ="__files/responses/material_type_by_id_response.json";
   public static final String MATERIAL_TYPE_OF_MEMBER_FROM_CENTRAL_TENANT_PATH ="__files/responses/material_type_of_member_from_central_tenant_response.json";
   public static final String MATERIAL_TYPE_OF_MEMBER_FROM_CENTRAL_TENANT_NOT_FOUND_PATH ="__files/errors/not_found.json";
@@ -84,6 +85,7 @@ public class TestConstants {
   public static final String GET_ALTERNATIVE_TITLE_TYPES_URL = "/inventory/alternative-title-types";
   public static final String GET_SUBJECT_SOURCES_URL = "/inventory/subject-sources";
   public static final String GET_SUBJECT_TYPES_URL = "/inventory/subject-types";
+  public static final String GET_MATERIAL_TYPES_COLLECTION_URL = "/inventory/material-types";
   public static final String GET_MATERIAL_TYPES_URL = "/inventory/material-types/40db37f8-2500-402c-bfd1-8b4764e738d0";
   public static final String INSTITUTION_ID = "6ecd8132-caef-4f87-bbb0-9fc07d71357d";
   public static final String LIBRARY_ID = "5d78803e-ca04-4b4a-aeae-2c63b924518b";

--- a/src/test/java/org/folio/edge/inventory/controller/InventoryControllerIT.java
+++ b/src/test/java/org/folio/edge/inventory/controller/InventoryControllerIT.java
@@ -24,6 +24,7 @@ import static org.folio.edge.inventory.TestConstants.GET_ITEMS_URL;
 import static org.folio.edge.inventory.TestConstants.GET_LIBRARY_BY_ID_NOT_FOUND_URL;
 import static org.folio.edge.inventory.TestConstants.GET_LIBRARY_BY_ID_URL;
 import static org.folio.edge.inventory.TestConstants.GET_LOCATION_VALID_URL;
+import static org.folio.edge.inventory.TestConstants.GET_MATERIAL_TYPES_COLLECTION_URL;
 import static org.folio.edge.inventory.TestConstants.GET_MATERIAL_TYPE_BY_ID_NOT_FOUND_URL;
 import static org.folio.edge.inventory.TestConstants.GET_MATERIAL_TYPE_BY_ID_URL;
 import static org.folio.edge.inventory.TestConstants.GET_MODES_OF_ISSUANCE_URL;
@@ -520,6 +521,24 @@ class InventoryControllerIT extends BaseIntegrationTests {
   void getCampusById_shouldReturnNotFound() throws Exception {
     doGet(mockMvc, GET_CAMPUS_BY_ID_NOT_FOUND_URL)
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getMaterialTypes_shouldReturnMaterialTypes() throws Exception {
+    doGetWithParams(mockMvc, GET_MATERIAL_TYPES_COLLECTION_URL, LANG_PARAM_NAME, LANG_PARAM_VALID_VALUE)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("mtypes[0].id", is("79a28446-25ed-4be6-8821-20b57cae0677")))
+        .andExpect(jsonPath("mtypes[0].name", is("Audio CD")))
+        .andExpect(jsonPath("mtypes[0].source", is("local")))
+        .andExpect(jsonPath("mtypes[1].name", is("book")))
+        .andExpect(jsonPath("totalRecords", is(2)));
+  }
+
+  @Test
+  void getMaterialTypes_shouldReturn200WithEmptyRecords_whenNoMaterialTypesFoundByQuery() throws Exception {
+    doGetWithParams(mockMvc, GET_MATERIAL_TYPES_COLLECTION_URL, QUERY_PARAM_NAME, "id==test")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("totalRecords", is(0)));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
@@ -24,6 +24,7 @@ import static org.folio.edge.inventory.TestConstants.LANG_PARAM_VALID_VALUE;
 import static org.folio.edge.inventory.TestConstants.LIBRARY_BY_ID_PATH;
 import static org.folio.edge.inventory.TestConstants.LIBRARY_ID;
 import static org.folio.edge.inventory.TestConstants.LOCATIONS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.MATERIAL_TYPES_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.MATERIAL_TYPE_BY_ID_PATH;
 import static org.folio.edge.inventory.TestConstants.MATERIAL_TYPE_ID;
 import static org.folio.edge.inventory.TestConstants.MODES_OF_ISSUANCE_RESPONSE_PATH;
@@ -401,6 +402,21 @@ class InventoryServiceTest {
     assertEquals("City Campus", campusJson.get("name"));
     assertEquals("CC", campusJson.get("code"));
     assertEquals("40ee00ca-a518-4b49-be01-0638d0a4ac57", campusJson.get("institutionId"));
+  }
+
+  @Test
+  void getMaterialTypes_shouldReturnMaterialTypes() throws JSONException {
+    String expectedMaterialTypesContent = TestUtil.readFileContentFromResources(MATERIAL_TYPES_RESPONSE_PATH);
+    RequestQueryParameters requestQueryParameters = new RequestQueryParameters();
+    when(inventoryClient.getMaterialTypes(requestQueryParameters)).thenReturn(expectedMaterialTypesContent);
+
+    JSONObject materialTypes = new JSONObject(inventoryService.getMaterialTypes(requestQueryParameters));
+    JSONObject firstMaterialType = materialTypes.getJSONArray("mtypes").getJSONObject(0);
+
+    assertEquals(2, materialTypes.get(TOTAL_RECORDS));
+    assertEquals("79a28446-25ed-4be6-8821-20b57cae0677", firstMaterialType.get(ID));
+    assertEquals("Audio CD", firstMaterialType.get(NAME));
+    assertEquals("local", firstMaterialType.get(SOURCE));
   }
 
   @Test

--- a/src/test/resources/__files/responses/material_types_empty_response.json
+++ b/src/test/resources/__files/responses/material_types_empty_response.json
@@ -1,0 +1,4 @@
+{
+  "mtypes": [],
+  "totalRecords": 0
+}

--- a/src/test/resources/__files/responses/material_types_response.json
+++ b/src/test/resources/__files/responses/material_types_response.json
@@ -1,0 +1,27 @@
+{
+  "mtypes": [
+    {
+      "id": "79a28446-25ed-4be6-8821-20b57cae0677",
+      "name": "Audio CD",
+      "source": "local",
+      "metadata": {
+        "createdDate": "2020-02-26T01:56:03.738+00:00",
+        "createdByUserId": "d916e883-f8f1-4188-bc1d-f0dce1511b50",
+        "updatedDate": "2020-02-26T01:56:03.738+00:00",
+        "updatedByUserId": "d916e883-f8f1-4188-bc1d-f0dce1511b50"
+      }
+    },
+    {
+      "id": "d9acad2f-2aac-4b48-9097-e6ab85906b25",
+      "name": "book",
+      "source": "folio",
+      "metadata": {
+        "createdDate": "2021-03-14T12:30:00.000+00:00",
+        "createdByUserId": "d916e883-f8f1-4188-bc1d-f0dce1511b50",
+        "updatedDate": "2021-03-14T12:30:00.000+00:00",
+        "updatedByUserId": "d916e883-f8f1-4188-bc1d-f0dce1511b50"
+      }
+    }
+  ],
+  "totalRecords": 2
+}

--- a/src/test/resources/mappings/material_types.json
+++ b/src/test/resources/mappings/material_types.json
@@ -3,6 +3,32 @@
     {
       "request": {
         "method": "GET",
+        "url": "/material-types?offset=0&limit=10&lang=en"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/material_types_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "/material-types?offset=0&query=id%3D%3Dtest&limit=10&lang=en"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/material_types_empty_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
         "url": "/material-types/79a28446-25ed-4be6-8821-20b57cae0677"
       },
       "response": {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGEINV-27

As part of the effort to remove inventory and user-related endpoints from edge-orders (see parent story), the /material-types-for-order endpoint was deleted from edge-orders. The Mosaic team and other consumers should now use edge-inventory instead. Edge-inventory already exposes GET /inventory/material-types/{materialTypeId} for retrieving a single material type by ID, but it is missing the collection endpoint needed to retrieve and search material types. This story adds that missing endpoint so that edge-inventory fully covers the functionality previously provided by edge-orders. 