### PR TITLE
EDGEINV-33: Do self-evaluation for TC approval

### DIFF
--- a/.github/workflows/tc-evaluation.yml
+++ b/.github/workflows/tc-evaluation.yml
@@ -1,0 +1,44 @@
+name: TC Module Evaluation
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to evaluate (defaults to current ref)'
+        required: false
+        type: string
+      output_format:
+        description: 'Report format'
+        required: false
+        type: choice
+        options:
+          - both
+          - json-only
+          - html-only
+        default: 'both'
+      criteria_filter:
+        description: 'Comma-separated criterion IDs (e.g., S001,S002,B005). Leave empty for all.'
+        required: false
+        type: string
+      java_version:
+        description: 'Java version'
+        required: false
+        type: string
+        default: '21'
+      node_version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '20'
+
+jobs:
+  evaluate:
+    permissions:
+      contents: read
+    uses: folio-org/tc-module-eval/.github/workflows/evaluate.yml@master
+    with:
+      ref: ${{ inputs.ref }}
+      output_format: ${{ inputs.output_format }}
+      criteria_filter: ${{ inputs.criteria_filter }}
+      java_version: ${{ inputs.java_version }}
+      node_version: ${{ inputs.node_version }}

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -1,0 +1,27 @@
+# Environment Variables
+
+This table documents the operator-facing environment variables declared by `edge-inventory`.
+Generic Spring Boot environment variables are supported by the framework and are not exhaustively listed here.
+
+| Name | Default | Required | Description |
+| --- | --- | --- | --- |
+| `JAVA_OPTIONS` | `-XX:MaxRAMPercentage=66.0` | false | Java runtime options for the module container. |
+| `SERVER_PORT` | `8080` | false | HTTP port used by the embedded Spring Boot server. |
+| `FOLIO_ENVIRONMENT` | `dev` | false | FOLIO environment name used by folio-spring-system-user configuration. |
+| `FOLIO_CLIENT_OKAPIURL` | `http://localhost:9130` | false | Okapi base URL used for outbound FOLIO service calls. |
+| `FOLIO_CLIENT_TLS_ENABLED` | `false` | false | Enables custom TLS truststore configuration for outbound Okapi/client calls. |
+| `FOLIO_CLIENT_TLS_TRUSTSTOREPATH` |  | false | Path to the outbound client TLS truststore. Required only when `FOLIO_CLIENT_TLS_ENABLED` is true and the server certificate is not trusted by the default JVM truststore. |
+| `FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD` |  | false | Password for the outbound client TLS truststore. |
+| `FOLIO_CLIENT_TLS_TRUSTSTORETYPE` |  | false | Type of the outbound client TLS truststore, for example `JKS`, `PKCS12`, or `BCFKS`. If unset, the JVM default truststore type is used. |
+| `SECURE_STORE_PROPS` | `src/main/resources/ephemeral.properties` | false | Path or URL to the edge secure-store properties file used to configure the secure store for institutional user credentials. |
+| `API_KEY_SOURCES` | `PARAM,HEADER,PATH` | false | Comma-separated list of locations where the edge API key is accepted. Valid values are `PARAM`, `HEADER`, and `PATH`. |
+| `TOKEN_CACHE_TTL_MS` | `3600000` | false | Time to live, in milliseconds, for successful Okapi token cache entries. |
+| `NULL_TOKEN_CACHE_TTL_MS` | `30000` | false | Time to live, in milliseconds, for failed or null Okapi token cache entries. |
+| `TOKEN_CACHE_CAPACITY` | `100` | false | Maximum number of Okapi token entries held by the in-memory edge token cache. |
+| `EDGE_SECURITY_FILTER_ENABLED` | `true` | false | Enables the edge API key security filter. |
+| `HEADER_EDGE_VALIDATION_EXCLUDE` | `/admin/health,/admin/info,/swagger-resources,/v2/api-docs,/swagger-ui,/_/tenant` | false | Comma-separated list of request path prefixes excluded from edge API key validation. |
+
+## Framework Variables
+
+The module also runs on Spring Boot and supports standard Spring environment variables through framework relaxed binding.
+Examples include `SPRING_PROFILES_ACTIVE`, `SERVER_SSL_BUNDLE`, and `SPRING_SSL_BUNDLE_JKS_*` variables for TLS bundles.

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -8,7 +8,7 @@ Generic Spring Boot environment variables are supported by the framework and are
 | `JAVA_OPTIONS` | `-XX:MaxRAMPercentage=66.0` | false | Java runtime options for the module container. |
 | `SERVER_PORT` | `8080` | false | HTTP port used by the embedded Spring Boot server. |
 | `FOLIO_ENVIRONMENT` | `dev` | false | FOLIO environment name used by folio-spring-system-user configuration. |
-| `FOLIO_CLIENT_OKAPIURL` | `http://localhost:9130` | false | Okapi base URL used for outbound FOLIO service calls. |
+| `FOLIO_CLIENT_OKAPIURL` |  | true | Okapi base URL used for outbound FOLIO service calls. |
 | `FOLIO_CLIENT_TLS_ENABLED` | `false` | false | Enables custom TLS truststore configuration for outbound Okapi/client calls. |
 | `FOLIO_CLIENT_TLS_TRUSTSTOREPATH` |  | false | Path to the outbound client TLS truststore. Required only when `FOLIO_CLIENT_TLS_ENABLED` is true and the server certificate is not trusted by the default JVM truststore. |
 | `FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD` |  | false | Password for the outbound client TLS truststore. |
@@ -21,7 +21,4 @@ Generic Spring Boot environment variables are supported by the framework and are
 | `EDGE_SECURITY_FILTER_ENABLED` | `true` | false | Enables the edge API key security filter. |
 | `HEADER_EDGE_VALIDATION_EXCLUDE` | `/admin/health,/admin/info,/swagger-resources,/v2/api-docs,/swagger-ui,/_/tenant` | false | Comma-separated list of request path prefixes excluded from edge API key validation. |
 
-## Framework Variables
 
-The module also runs on Spring Boot and supports standard Spring environment variables through framework relaxed binding.
-Examples include `SPRING_PROFILES_ACTIVE`, `SERVER_SSL_BUNDLE`, and `SPRING_SSL_BUNDLE_JKS_*` variables for TLS bundles.

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -5,8 +5,8 @@
 * [x] Third party dependencies use an Apache 2.0 compatible license
 * [x] Installation documentation is included
     * -_note: read more at https://github.com/folio-org/mod-search/blob/master/README.md_
-* [] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
-* [] Sensitive and environment-specific information is not checked into git repository
+* [x] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
+* [x] Sensitive and environment-specific information is not checked into git repository
 * [x] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
 * [x] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
 * [x] Module gracefully handles the absence of third party systems or related configuration

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -18,7 +18,7 @@
 * [x] Module's repository includes a compliant Module Descriptor
     * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
 * [x] Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
-* [] Environment vars are documented in the ModuleDescriptor
+* [x] Environment vars are documented in the ModuleDescriptor
     * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
 * [x] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
 * [x] All API endpoints are documented in RAML or OpenAPI
@@ -40,4 +40,3 @@
         * Services are stateful
 * [x] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
     * _e.g. PostgreSQL, ElasticSearch, etc._
-

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -1,0 +1,43 @@
+## Shared/Common
+* [x] Uses Apache 2.0 license
+* [x] Module build MUST produce a valid module descriptor
+* [x] Module descriptor MUST include interface requirements for all consumed APIs
+* [x] Third party dependencies use an Apache 2.0 compatible license
+* [x] Installation documentation is included
+    * -_note: read more at https://github.com/folio-org/mod-search/blob/master/README.md_
+* [] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
+* [] Sensitive and environment-specific information is not checked into git repository
+* [x] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
+* [x] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
+* [x] Module gracefully handles the absence of third party systems or related configuration
+* [] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
+* [x] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
+* [] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+
+## Backend
+* [x] Module's repository includes a compliant Module Descriptor
+    * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
+* [x] Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
+* [] Environment vars are documented in the ModuleDescriptor
+    * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
+* [x] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
+* [x] All API endpoints are documented in RAML or OpenAPI
+* [] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
+    * -_note: read more at https://dev.folio.org/guidelines/naming-conventions/ and https://wiki.folio.org/display/DD/Permission+Set+Guidelines_
+* [] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
+* [] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+    * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
+    * -_note: these tests are defined in https://github.com/folio-org/folio-integration-tests_
+* [] Data is segregated by tenant at the storage layer
+* [x] The module doesn't access data in DB schemas other than its own and public
+* [x] The module responds with a tenant's content based on x-okapi-tenant header
+* [x] Standard GET `/admin/health` endpoint returning a 200 response
+    * -_note: read more at https://wiki.folio.org/display/DD/Back+End+Module+Health+Check+Protocol_
+* [x] High Availability (HA) compliant
+    * Possible red flags:
+        * Connection affinity / sticky sessions / etc. are used
+        * Local container storage is used
+        * Services are stateful
+* [x] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
+    * _e.g. PostgreSQL, ElasticSearch, etc._
+

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -10,7 +10,7 @@
 * [x] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
 * [x] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
 * [x] Module gracefully handles the absence of third party systems or related configuration
-* [] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
+* [x] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
 * [x] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
 * [x] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
 
@@ -22,7 +22,7 @@
     * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
 * [x] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
 * [x] All API endpoints are documented in RAML or OpenAPI
-* [] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
+* [x] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
     * -_note: read more at https://dev.folio.org/guidelines/naming-conventions/ and https://wiki.folio.org/display/DD/Permission+Set+Guidelines_
 * [] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
 * [] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -12,7 +12,7 @@
 * [x] Module gracefully handles the absence of third party systems or related configuration
 * [] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
 * [x] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
-* [] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+* [x] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
 
 ## Backend
 * [x] Module's repository includes a compliant Module Descriptor

--- a/PERSONAL_DATA_DISCLOSURE.md
+++ b/PERSONAL_DATA_DISCLOSURE.md
@@ -13,6 +13,7 @@ For the purposes of this form, "store" includes the following:
 
 ## Personal Data Stored by This Module
 - [x] This module does not store any personal data.
+- [x] This module transmits personal data (including queues, additional databases, etc.)
 - [ ] This module provides [custom fields](https://github.com/folio-org/folio-custom-fields).
 - [ ] This module stores fields with free-form text (tags, notes, descriptions, etc.)
 - [ ] This module caches personal data

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Institutional users should be granted the following permission in order to use t
 ## Configuration
 
 * See [edge-common](https://github.com/folio-org/edge-common) for a description of how configuration works.
+* See [ENV_VARS.md](ENV_VARS.md) for the environment variables declared by this module.
 
 ## Configuration
 
@@ -137,4 +138,3 @@ FOLIO_CLIENT_TLS_TRUSTSTOREPATH=classpath:test/test.truststore.bcfks
 FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD=SecretPassword
 FOLIO_CLIENT_TLS_TRUSTSTORETYPE=bcfks
 ```
-

--- a/README.md
+++ b/README.md
@@ -138,3 +138,17 @@ FOLIO_CLIENT_TLS_TRUSTSTOREPATH=classpath:test/test.truststore.bcfks
 FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD=SecretPassword
 FOLIO_CLIENT_TLS_TRUSTSTORETYPE=bcfks
 ```
+
+## ASF Category B license notice
+
+Apache's [third-party license policy](https://www.apache.org/legal/resolved.html#category-b) allows Category B dependencies
+only under the conditions described there. The dependency license scan for this project reported the following dependencies
+whose detected licenses match ASF Category B license families:
+
+| Project | Detected dependency or dependencies | Detected license | Project URL |
+|---|---|---|---|
+| Jakarta Activation | `jakarta.activation:jakarta.activation-api:2.1.4` | EPL-1.0 | <https://jakarta.ee/specifications/activation/> |
+| Jakarta XML Binding | `jakarta.xml.bind:jakarta.xml.bind-api:4.0.4` | EPL-1.0 | <https://jakarta.ee/specifications/xml-binding/> |
+| Eclipse Sisu | `org.eclipse.sisu:org.eclipse.sisu.plexus:0.9.0.M2` | Eclipse Public License 1.0 | <https://www.eclipse.org/sisu/> |
+| JUnit 5 | `org.junit.jupiter:junit-jupiter-api:6.0.3`<br>`org.junit.jupiter:junit-jupiter-engine:6.0.3`<br>`org.junit.jupiter:junit-jupiter-params:6.0.3`<br>`org.junit.platform:junit-platform-commons:6.0.3`<br>`org.junit.platform:junit-platform-engine:6.0.3` | EPL-2.0 | <https://junit.org/junit5/> |
+| Mozilla Rhino | `org.mozilla:rhino:1.9.1` | Mozilla Public License 2.0 | <https://github.com/mozilla/rhino> |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See [edge-common-spring](https://github.com/folio-org/edge-common-spring)
 ## Requires Permissions
 
 Institutional users should be granted the following permission in order to use this edge API:
-- `"inventory.instances.item.get"`
+- `inventory.instances.item.get`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ whose detected licenses match ASF Category B license families:
 
 | Project | Detected dependency or dependencies | Detected license | Project URL |
 |---|---|---|---|
-| Jakarta Activation | `jakarta.activation:jakarta.activation-api:2.1.4` | EPL-1.0 | <https://jakarta.ee/specifications/activation/> |
-| Jakarta XML Binding | `jakarta.xml.bind:jakarta.xml.bind-api:4.0.4` | EPL-1.0 | <https://jakarta.ee/specifications/xml-binding/> |
+| JAXB API | `javax.xml.bind:jaxb-api:2.3.1` | CDDL 1.1 or GPL2 w/ CPE | <https://github.com/javaee/jaxb-spec> |
 | Eclipse Sisu | `org.eclipse.sisu:org.eclipse.sisu.plexus:0.9.0.M2` | Eclipse Public License 1.0 | <https://www.eclipse.org/sisu/> |
-| JUnit 5 | `org.junit.jupiter:junit-jupiter-api:6.0.3`<br>`org.junit.jupiter:junit-jupiter-engine:6.0.3`<br>`org.junit.jupiter:junit-jupiter-params:6.0.3`<br>`org.junit.platform:junit-platform-commons:6.0.3`<br>`org.junit.platform:junit-platform-engine:6.0.3` | EPL-2.0 | <https://junit.org/junit5/> |
+| Jakarta Annotations | `jakarta.annotation:jakarta.annotation-api:3.0.0` | EPL 2.0 or GPL2 w/ CPE | <https://projects.eclipse.org/projects/ee4j.ca> |
+| JUnit Jupiter | `org.junit.jupiter:junit-jupiter:6.0.3`<br>`org.junit.jupiter:junit-jupiter-api:6.0.3`<br>`org.junit.jupiter:junit-jupiter-engine:6.0.3`<br>`org.junit.jupiter:junit-jupiter-params:6.0.3` | EPL-2.0 | <https://junit.org/junit5/> |
+| JUnit Platform | `org.junit.platform:junit-platform-commons:6.0.3`<br>`org.junit.platform:junit-platform-engine:6.0.3` | EPL-2.0 | <https://junit.org/junit5/> |
 | Mozilla Rhino | `org.mozilla:rhino:1.9.1` | Mozilla Public License 2.0 | <https://github.com/mozilla/rhino> |

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -83,5 +83,6 @@
         "value": "-XX:MaxRAMPercentage=66.0"
       }
     ]
-  }
+  },
+  "env": []
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -105,9 +105,9 @@
     },
     {
       "name": "FOLIO_CLIENT_OKAPIURL",
-      "value": "http://localhost:9130",
+      "value": "",
       "description": "Okapi base URL used for outbound FOLIO service calls.",
-      "required": false
+      "required": true
     },
     {
       "name": "FOLIO_CLIENT_TLS_ENABLED",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -84,5 +84,96 @@
       }
     ]
   },
-  "env": []
+  "env": [
+    {
+      "name": "JAVA_OPTIONS",
+      "value": "-XX:MaxRAMPercentage=66.0",
+      "description": "Java runtime options for the module container.",
+      "required": false
+    },
+    {
+      "name": "SERVER_PORT",
+      "value": "8080",
+      "description": "HTTP port used by the embedded Spring Boot server.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_ENVIRONMENT",
+      "value": "dev",
+      "description": "FOLIO environment name used by folio-spring-system-user configuration.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_OKAPIURL",
+      "value": "http://localhost:9130",
+      "description": "Okapi base URL used for outbound FOLIO service calls.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_ENABLED",
+      "value": "false",
+      "description": "Enables custom TLS truststore configuration for outbound Okapi/client calls.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_TRUSTSTOREPATH",
+      "value": "",
+      "description": "Path to the outbound client TLS truststore. Required only when FOLIO_CLIENT_TLS_ENABLED is true and the server certificate is not trusted by the default JVM truststore.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD",
+      "value": "",
+      "description": "Password for the outbound client TLS truststore.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_TRUSTSTORETYPE",
+      "value": "",
+      "description": "Type of the outbound client TLS truststore, for example JKS, PKCS12, or BCFKS. If unset, the JVM default truststore type is used.",
+      "required": false
+    },
+    {
+      "name": "SECURE_STORE_PROPS",
+      "value": "src/main/resources/ephemeral.properties",
+      "description": "Path or URL to the edge secure-store properties file used to configure the secure store for institutional user credentials.",
+      "required": false
+    },
+    {
+      "name": "API_KEY_SOURCES",
+      "value": "PARAM,HEADER,PATH",
+      "description": "Comma-separated list of locations where the edge API key is accepted. Valid values are PARAM, HEADER, and PATH.",
+      "required": false
+    },
+    {
+      "name": "TOKEN_CACHE_TTL_MS",
+      "value": "3600000",
+      "description": "Time to live, in milliseconds, for successful Okapi token cache entries.",
+      "required": false
+    },
+    {
+      "name": "NULL_TOKEN_CACHE_TTL_MS",
+      "value": "30000",
+      "description": "Time to live, in milliseconds, for failed or null Okapi token cache entries.",
+      "required": false
+    },
+    {
+      "name": "TOKEN_CACHE_CAPACITY",
+      "value": "100",
+      "description": "Maximum number of Okapi token entries held by the in-memory edge token cache.",
+      "required": false
+    },
+    {
+      "name": "EDGE_SECURITY_FILTER_ENABLED",
+      "value": "true",
+      "description": "Enables the edge API key security filter.",
+      "required": false
+    },
+    {
+      "name": "HEADER_EDGE_VALIDATION_EXCLUDE",
+      "value": "/admin/health,/admin/info,/swagger-resources,/v2/api-docs,/swagger-ui,/_/tenant",
+      "description": "Comma-separated list of request path prefixes excluded from edge API key validation.",
+      "required": false
+    }
+  ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
 
     <!-- Test dependencies versions -->
     <wiremock-standalone.version>3.13.2</wiremock-standalone.version>
+
+    <!-- Downgrade Liquibase to 4.33.0 to avoid FSL license in v5. This is the TC recommendation for new modules. -->
+    <liquibase.version>4.33.0</liquibase.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,9 @@
               <generateSupportingFiles>true</generateSupportingFiles>
               <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
               <generateModelDocumentation>true</generateModelDocumentation>
-              <inlineSchemaNameDefaults>arrayItemSuffix=</inlineSchemaNameDefaults>
+              <inlineSchemaOptions>
+                <inlineSchemaOption>ARRAY_ITEM_SUFFIX=_inner</inlineSchemaOption>
+              </inlineSchemaOptions>
               <configOptions>
                 <java8>true</java8>
                 <dateLibrary>java</dateLibrary>

--- a/src/main/java/org/folio/edge/inventory/models/InventoryViewJsonFields.java
+++ b/src/main/java/org/folio/edge/inventory/models/InventoryViewJsonFields.java
@@ -1,6 +1,6 @@
 package org.folio.edge.inventory.models;
 
-public class InventoryViewJsonFields {
+public final class InventoryViewJsonFields {
   public static final String TOTAL_RECORDS = "totalRecords";
   public static final String INSTANCES = "instances";
   public static final String INSTANCE_ID = "instanceId";
@@ -8,4 +8,7 @@ public class InventoryViewJsonFields {
   public static final String HOLDINGS_RECORDS = "holdingsRecords";
   public static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
   public static final String ITEMS = "items";
+
+  private InventoryViewJsonFields() {
+  }
 }

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -35,6 +35,7 @@ public class EcsInventoryService {
   public static final String FACET = "holdings.tenantId";
   private static final Pattern HOLDINGS_ID_PATTERN = Pattern.compile(HOLDINGS_RECORD_ID + "==\\(([^)]+)\\)");
   private static final Pattern INSTANCE_ID_PATTERN = Pattern.compile("(instance(?:\\.id|Id))==([a-fA-F0-9\\-]{36})");
+  private static final Pattern HOLDINGS_ID_SEPARATOR_PATTERN = Pattern.compile(" or ");
   private final UserClient userClient;
   private final InventoryClient inventoryClient;
   private final SearchClient searchClient;
@@ -66,7 +67,7 @@ public class EcsInventoryService {
   private List<String> getInstanceIdsFromView(JsonNode instanceView) {
     var instanceIds = new ArrayList<String>();
     instanceView.withArray(INSTANCES).elements()
-        .forEach((instance) -> instanceIds.add(instance.get(INSTANCE_ID).asString()));
+        .forEach(instance -> instanceIds.add(instance.get(INSTANCE_ID).asString()));
     return instanceIds;
   }
 
@@ -236,7 +237,7 @@ public class EcsInventoryService {
     var matcher = HOLDINGS_ID_PATTERN.matcher(query);
     if (matcher.find()) {
       var insideParentheses = matcher.group(1);
-      var ids = insideParentheses.split(" or ");
+      var ids = HOLDINGS_ID_SEPARATOR_PATTERN.split(insideParentheses);
       if (ids.length > 0) {
         return ids[0].trim();
       }

--- a/src/test/java/org/folio/edge/inventory/BaseIntegrationTests.java
+++ b/src/test/java/org/folio/edge/inventory/BaseIntegrationTests.java
@@ -9,7 +9,6 @@ import java.util.List;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.folio.edgecommonspring.client.EdgeClientProperties;
-import org.folio.spring.config.properties.FolioEnvironment;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -42,8 +41,7 @@ public abstract class BaseIntegrationTests {
   protected MockMvc mockMvc;
 
   @BeforeAll
-  static void beforeAll(@Autowired EdgeClientProperties edgeClientProperties,
-      @Autowired FolioEnvironment folioEnvironment) {
+  static void beforeAll(@Autowired EdgeClientProperties edgeClientProperties) {
     WIRE_MOCK.start();
     ReflectionTestUtils.setField(edgeClientProperties, TestConstants.OKAPI_URL_FIELD, WIRE_MOCK.baseUrl());
     log.info("Wire mock started");

--- a/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
@@ -44,7 +44,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
-public class EcsInventoryServiceTest {
+class EcsInventoryServiceTest {
 
   @Mock
   private UserClient usersClient;

--- a/src/test/java/org/folio/edge/inventory/service/EcsLocationsServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsLocationsServiceTest.java
@@ -17,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
-public class EcsLocationsServiceTest {
+class EcsLocationsServiceTest {
 
   @Mock
   private SearchClient searchClient;

--- a/src/test/java/org/folio/edge/inventory/service/EcsMaterialTypeServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsMaterialTypeServiceTest.java
@@ -34,7 +34,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
-public class EcsMaterialTypeServiceTest {
+class EcsMaterialTypeServiceTest {
 
   @Mock
   private ConsortiaClient consortiaClient;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGEINV-33

Summary of changes.
* Adds newly required env vars documentation
* Adds [Category B](https://www.apache.org/legal/resolved.html#category-b) license information to readme (also new requirement)
* Went through and checked off all the stuff in self eval file
* Downgrade Liqubase to 4.33 per TC recommendation because it is no longer Category B but Category X in 5.x
* Add tc-evalution GH workflow
* Get rid of red squiggly in pom about `inlineSchemaNameDefaults` without changing behavior

Sonar fixes:
* Remove the unused @Autowired FolioEnvironment folioEnvironment parameter and its import.
* Add a private static final Pattern for the " or " separator and replace insideParentheses.split(" or ") with that pattern’s split(...).
* Make the constants class non-instantiable, a public final class ... plus a private constructor.
* Remove unnecessary lambda parenthesis.
* Remove public members that aren't needed. 