### PR TITLE
EDGEINV-34: Create new endpoint to support new inventory instance summary in mod-inventory and mod-inventory storage

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -40,6 +40,10 @@
       "version": "2.0"
     },
     {
+      "id": "instance-storage",
+      "version": "11.4"
+    },
+    {
       "id": "instance-note-types",
       "version": "1.0"
     },

--- a/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
+++ b/src/main/java/org/folio/edge/inventory/client/InventoryClient.java
@@ -15,6 +15,9 @@ public interface InventoryClient {
   @GetExchange("inventory/instances/{instanceId}")
   JsonNode getInstance(@PathVariable("instanceId") String instanceId, @RequestParam String lang);
 
+  @GetExchange("instance-storage/instances/{instanceId}/summary")
+  JsonNode getInstanceSummary(@PathVariable("instanceId") String instanceId);
+
   @GetExchange("inventory/instances")
   JsonNode getInstancesByQuery(@RequestParam Map<String, ?> requestQueryParameters);
 

--- a/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
+++ b/src/main/java/org/folio/edge/inventory/controller/InventoryController.java
@@ -33,6 +33,15 @@ public class InventoryController implements InventoryApi {
   }
 
   @Override
+  public ResponseEntity<String> getInstanceSummary(String instanceId, String xOkapiTenant, String xOkapiToken) {
+    log.info("Retrieving instance summary by given id {}", instanceId);
+    if (ecsInventoryService.isCentralTenant(xOkapiTenant)) {
+      return ResponseEntity.ok(ecsInventoryService.getEcsInstanceSummary(instanceId, xOkapiTenant));
+    }
+    return ResponseEntity.ok(inventoryService.getInstanceSummary(instanceId));
+  }
+
+  @Override
   public ResponseEntity<String> getInstancesByQuery(String xOkapiTenant, String xOkapiToken,
       RequestQueryParameters requestQueryParameters) {
     log.info("Retrieving instances by query {}", requestQueryParameters.getQuery());

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -10,6 +10,7 @@ import static org.folio.edge.inventory.models.InventoryViewJsonFields.TOTAL_RECO
 import static org.folio.spring.utils.FolioExecutionContextUtils.prepareContextForTenant;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -196,10 +197,13 @@ public class EcsInventoryService {
     Comparator<JsonNode> namedValueComparator = Comparator
         .comparing((JsonNode node) -> stringValue(node, NAME), Comparator.nullsLast(String::compareTo))
         .thenComparing(this::namedValueKey);
+    Comparator<JsonNode> electronicAccessComparator = Comparator
+        .comparing((JsonNode node) -> stringValue(node, URI), Comparator.nullsLast(String::compareTo))
+        .thenComparing(this::electronicAccessKey);
     mergeEffectiveShelvingOrder(target, source, scope);
-    mergeArray(target, source, jsonPointer(AGGREGATES, scope), ELECTRONIC_ACCESS,
-        this::electronicAccessKey, null);
-    mergeArray(target, source, jsonPointer(AGGREGATES, scope, REFERENCE_VALUES), ITEM_MATERIAL_TYPES,
+    mergeArray(target, source, new String[] {AGGREGATES, scope}, ELECTRONIC_ACCESS,
+        this::electronicAccessKey, electronicAccessComparator);
+    mergeArray(target, source, new String[] {AGGREGATES, scope, REFERENCE_VALUES}, ITEM_MATERIAL_TYPES,
         this::namedValueKey, namedValueComparator);
   }
 
@@ -225,12 +229,12 @@ public class EcsInventoryService {
     return value1.compareTo(value2) <= 0 ? value1 : value2;
   }
 
-  private void mergeArray(JsonNode target, JsonNode source, String parentPointer, String arrayName,
+  private void mergeArray(JsonNode target, JsonNode source, String[] parentPath, String arrayName,
       Function<JsonNode, String> keyProvider, Comparator<JsonNode> comparator) {
     var merged = new LinkedHashMap<String, JsonNode>();
-    var targetParent = target.withObject(parentPointer);
+    var targetParent = target.withObject(jsonPointer(parentPath));
     addArrayValues(merged, getNode(targetParent, arrayName), keyProvider);
-    addArrayValues(merged, getNode(source, path(parentPointer, arrayName)), keyProvider);
+    addArrayValues(merged, getNode(source, append(parentPath, arrayName)), keyProvider);
 
     var values = new ArrayList<>(merged.values());
     if (comparator != null) {
@@ -264,9 +268,10 @@ public class EcsInventoryService {
     return id == null ? namedValue.toString() : id;
   }
 
-  private String[] path(String parentPointer, String fieldName) {
-    var path = parentPointer.substring(1) + JSON_POINTER_SEPARATOR + fieldName;
-    return path.split(String.valueOf(JSON_POINTER_SEPARATOR));
+  private String[] append(String[] pathSegments, String fieldName) {
+    var extendedPath = Arrays.copyOf(pathSegments, pathSegments.length + 1);
+    extendedPath[pathSegments.length] = fieldName;
+    return extendedPath;
   }
 
   private String jsonPointer(String... pathSegments) {

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -70,19 +70,17 @@ public class EcsInventoryService {
   private final RequestQueryParametersMapper requestQueryParametersMapper;
 
   public boolean isCentralTenant(String tenantId) {
-    var effectiveTenantId = effectiveTenantId(tenantId);
     var userTenants = userClient.getUserTenants();
     if (userTenants.getTotalRecords() > 0) {
-      return effectiveTenantId != null && effectiveTenantId.equals(userTenants.getUserTenants().getFirst().getCentralTenantId());
+      return tenantId.equals(userTenants.getUserTenants().getFirst().getCentralTenantId());
     }
     return false;
   }
 
   public String getEcsInstanceSummary(String instanceId, String currentTenantId) {
     var centralSummary = inventoryClient.getInstanceSummary(instanceId);
-    var effectiveTenantId = effectiveTenantId(currentTenantId);
     var memberTenantIds = getInstanceTenants(instanceId).tenantIds().stream()
-        .filter(tenantId -> !Objects.equals(tenantId, effectiveTenantId))
+        .filter(tenantId -> !Objects.equals(tenantId, currentTenantId))
         .toList();
     if (memberTenantIds.isEmpty()) {
       return centralSummary.toString();
@@ -91,11 +89,6 @@ public class EcsInventoryService {
     getInstanceSummaries(instanceId, memberTenantIds)
         .forEach(memberSummary -> mergeInstanceSummary(centralSummary, memberSummary));
     return centralSummary.toString();
-  }
-
-  private String effectiveTenantId(String tenantId) {
-    var contextTenantId = folioExecutionContext.getTenantId();
-    return contextTenantId == null ? tenantId : contextTenantId;
   }
 
   public String getEcsInventoryViewInstances(RequestQueryParameters requestQueryParameters, Boolean withBoundedItems) {

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -186,7 +186,7 @@ public class EcsInventoryService {
   }
 
   private void addCount(JsonNode target, JsonNode source, String recordType, String fieldName) {
-    var targetCounts = target.withObject(jsonPointer(RECORD_COUNTS, recordType));
+    var targetCounts = Objects.requireNonNull(target.withObject(jsonPointer(RECORD_COUNTS, recordType)));
     var sourceCounts = getNode(source, RECORD_COUNTS, recordType);
     targetCounts.put(fieldName, intValue(targetCounts, fieldName) + intValue(sourceCounts, fieldName));
   }
@@ -228,7 +228,7 @@ public class EcsInventoryService {
   private void mergeArray(JsonNode target, JsonNode source, String[] parentPath, String arrayName,
       Function<JsonNode, String> keyProvider, Comparator<JsonNode> comparator) {
     var merged = new LinkedHashMap<String, JsonNode>();
-    var targetParent = target.withObject(jsonPointer(parentPath));
+    var targetParent = Objects.requireNonNull(target.withObject(jsonPointer(parentPath)));
     addArrayValues(merged, getNode(targetParent, arrayName), keyProvider);
     addArrayValues(merged, getNode(source, append(parentPath, arrayName)), keyProvider);
 

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -188,9 +188,7 @@ public class EcsInventoryService {
   private void addCount(JsonNode target, JsonNode source, String recordType, String fieldName) {
     var targetCounts = target.withObject(jsonPointer(RECORD_COUNTS, recordType));
     var sourceCounts = getNode(source, RECORD_COUNTS, recordType);
-    if (targetCounts != null) {
-      targetCounts.put(fieldName, intValue(targetCounts, fieldName) + intValue(sourceCounts, fieldName));
-    }
+    targetCounts.put(fieldName, intValue(targetCounts, fieldName) + intValue(sourceCounts, fieldName));
   }
 
   private void mergeAggregateScope(JsonNode target, JsonNode source, String scope) {
@@ -209,13 +207,11 @@ public class EcsInventoryService {
 
   private void mergeEffectiveShelvingOrder(JsonNode target, JsonNode source, String scope) {
     var targetFields = target.withObject(jsonPointer(AGGREGATES, scope, ITEM_DERIVED_FIELDS));
-    if (targetFields != null) {
-      var targetValue = stringValue(targetFields, EFFECTIVE_SHELVING_ORDER);
-      var sourceValue = stringValue(getNode(source, AGGREGATES, scope, ITEM_DERIVED_FIELDS), EFFECTIVE_SHELVING_ORDER);
-      var mergedValue = firstShelvingOrder(targetValue, sourceValue);
-      if (mergedValue != null) {
-        targetFields.put(EFFECTIVE_SHELVING_ORDER, mergedValue);
-      }
+    var targetValue = stringValue(targetFields, EFFECTIVE_SHELVING_ORDER);
+    var sourceValue = stringValue(getNode(source, AGGREGATES, scope, ITEM_DERIVED_FIELDS), EFFECTIVE_SHELVING_ORDER);
+    var mergedValue = firstShelvingOrder(targetValue, sourceValue);
+    if (mergedValue != null) {
+      targetFields.put(EFFECTIVE_SHELVING_ORDER, mergedValue);
     }
   }
 
@@ -237,15 +233,11 @@ public class EcsInventoryService {
     addArrayValues(merged, getNode(source, append(parentPath, arrayName)), keyProvider);
 
     var values = new ArrayList<>(merged.values());
-    if (comparator != null) {
-      values.sort(comparator);
-    }
+    values.sort(comparator);
 
     var mergedArray = JsonNodeFactory.instance.arrayNode();
     values.forEach(mergedArray::add);
-    if (targetParent != null) {
-      targetParent.set(arrayName, mergedArray);
-    }
+    targetParent.set(arrayName, mergedArray);
   }
 
   private void addArrayValues(Map<String, JsonNode> valuesByKey, JsonNode arrayNode,
@@ -254,7 +246,7 @@ public class EcsInventoryService {
       return;
     }
     for (JsonNode value : values.elements()) {
-      if (value == null || value.isNull()) {
+      if (value.isNull()) {
         continue;
       }
       valuesByKey.putIfAbsent(keyProvider.apply(value), value);
@@ -262,19 +254,13 @@ public class EcsInventoryService {
   }
 
   private String electronicAccessKey(JsonNode electronicAccess) {
-    if (electronicAccess == null || electronicAccess.isNull()) {
-      return "";
-    }
     var uri = stringValue(electronicAccess, URI);
-    return uri == null ? electronicAccess.toString() : uri;
+    return uri == null ? Objects.toString(electronicAccess, "") : uri;
   }
 
   private String namedValueKey(JsonNode namedValue) {
-    if (namedValue == null || namedValue.isNull()) {
-      return "";
-    }
     var id = stringValue(namedValue, ID_FIELD);
-    return id == null ? namedValue.toString() : id;
+    return id == null ? Objects.toString(namedValue, "") : id;
   }
 
   private String[] append(String[] pathSegments, String fieldName) {

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -7,12 +7,17 @@ import static org.folio.edge.inventory.models.InventoryViewJsonFields.INSTANCES;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.INSTANCE_ID;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.ITEMS;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.TOTAL_RECORDS;
+import static org.folio.spring.utils.FolioExecutionContextUtils.prepareContextForTenant;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.folio.edge.inventory.client.InventoryClient;
@@ -26,13 +31,34 @@ import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 @Service
 @RequiredArgsConstructor
 public class EcsInventoryService {
 
   public static final String FACET = "holdings.tenantId";
+  private static final String AGGREGATES = "aggregates";
+  private static final String ALL_RECORDS = "allRecords";
+  private static final String ELECTRONIC_ACCESS = "electronicAccess";
+  private static final String EFFECTIVE_SHELVING_ORDER = "effectiveShelvingOrder";
+  private static final String ID_FIELD = "id";
+  private static final String IS_BOUND_WITH = "isBoundWith";
+  private static final String ITEM_DERIVED_FIELDS = "itemDerivedFields";
+  private static final String ITEM_MATERIAL_TYPES = "itemMaterialTypes";
+  private static final String NAME = "name";
+  private static final String NOT_SUPPRESSED_FROM_DISCOVERY_RECORDS = "notSuppressedFromDiscoveryRecords";
+  private static final String RECORD_COUNTS = "recordCounts";
+  private static final String REFERENCE_VALUES = "referenceValues";
+  private static final String SUMMARY_HOLDINGS = "holdings";
+  private static final String SUPPRESSED_BY_HOLDINGS = "suppressedByHoldings";
+  private static final String SUPPRESSED_FROM_DISCOVERY = "suppressedFromDiscovery";
+  private static final String SUPPRESSED_FROM_DISCOVERY_OR_BY_HOLDINGS = "suppressedFromDiscoveryOrByHoldings";
+  private static final String NOT_SUPPRESSED_FROM_DISCOVERY = "notSuppressedFromDiscovery";
+  private static final String SUMMARY_TOTAL = "total";
+  private static final String URI = "uri";
   private static final Pattern HOLDINGS_ID_PATTERN = Pattern.compile(HOLDINGS_RECORD_ID + "==\\(([^)]+)\\)");
   private static final Pattern INSTANCE_ID_PATTERN = Pattern.compile("(instance(?:\\.id|Id))==([a-fA-F0-9\\-]{36})");
   private final UserClient userClient;
@@ -42,11 +68,32 @@ public class EcsInventoryService {
   private final RequestQueryParametersMapper requestQueryParametersMapper;
 
   public boolean isCentralTenant(String tenantId) {
+    var effectiveTenantId = effectiveTenantId(tenantId);
     var userTenants = userClient.getUserTenants();
     if (userTenants.getTotalRecords() > 0) {
-      return tenantId.equals(userTenants.getUserTenants().get(0).getCentralTenantId());
+      return effectiveTenantId != null && effectiveTenantId.equals(userTenants.getUserTenants().get(0).getCentralTenantId());
     }
     return false;
+  }
+
+  public String getEcsInstanceSummary(String instanceId, String currentTenantId) {
+    var centralSummary = inventoryClient.getInstanceSummary(instanceId);
+    var effectiveTenantId = effectiveTenantId(currentTenantId);
+    var memberTenantIds = getInstanceTenants(instanceId).tenantIds().stream()
+        .filter(tenantId -> !Objects.equals(tenantId, effectiveTenantId))
+        .toList();
+    if (memberTenantIds.isEmpty()) {
+      return centralSummary.toString();
+    }
+
+    getInstanceSummaries(instanceId, memberTenantIds)
+        .forEach(memberSummary -> mergeInstanceSummary(centralSummary, memberSummary));
+    return centralSummary.toString();
+  }
+
+  private String effectiveTenantId(String tenantId) {
+    var contextTenantId = folioExecutionContext.getTenantId();
+    return contextTenantId == null ? tenantId : contextTenantId;
   }
 
   public String getEcsInventoryViewInstances(RequestQueryParameters requestQueryParameters, Boolean withBoundedItems) {
@@ -95,6 +142,14 @@ public class EcsInventoryService {
         .toList();
   }
 
+  private List<JsonNode> getInstanceSummaries(String instanceId, List<String> tenantIds) {
+    var context = (FolioExecutionContext) folioExecutionContext.getInstance();
+    return tenantIds.parallelStream()
+        .map(tenantId -> prepareContextForTenant(tenantId, context.getFolioModuleMetadata(), context)
+            .execute(() -> inventoryClient.getInstanceSummary(instanceId)))
+        .toList();
+  }
+
   private void mergeInstanceViews(JsonNode instanceView1, JsonNode instanceView2) {
     var instances1 = instanceView1.withArrayProperty(INSTANCES);
     var instances2 = instanceView2.withArrayProperty(INSTANCES);
@@ -108,6 +163,138 @@ public class EcsInventoryService {
         instance1.withArrayProperty(ITEMS).addAll(instance2.withArrayProperty(ITEMS));
       }
     }
+  }
+
+  private void mergeInstanceSummary(JsonNode target, JsonNode source) {
+    mergeBoundWith(target, source);
+    mergeRecordCounts(target, source);
+    mergeAggregateScope(target, source, ALL_RECORDS);
+    mergeAggregateScope(target, source, NOT_SUPPRESSED_FROM_DISCOVERY_RECORDS);
+  }
+
+  private void mergeBoundWith(JsonNode target, JsonNode source) {
+    if (target instanceof ObjectNode targetObject) {
+      targetObject.put(IS_BOUND_WITH, booleanValue(target, IS_BOUND_WITH) || booleanValue(source, IS_BOUND_WITH));
+    }
+  }
+
+  private void mergeRecordCounts(JsonNode target, JsonNode source) {
+    addCount(target, source, SUMMARY_HOLDINGS, SUMMARY_TOTAL);
+    addCount(target, source, SUMMARY_HOLDINGS, SUPPRESSED_FROM_DISCOVERY);
+    addCount(target, source, SUMMARY_HOLDINGS, NOT_SUPPRESSED_FROM_DISCOVERY);
+    addCount(target, source, ITEMS, SUMMARY_TOTAL);
+    addCount(target, source, ITEMS, SUPPRESSED_FROM_DISCOVERY);
+    addCount(target, source, ITEMS, SUPPRESSED_BY_HOLDINGS);
+    addCount(target, source, ITEMS, SUPPRESSED_FROM_DISCOVERY_OR_BY_HOLDINGS);
+    addCount(target, source, ITEMS, NOT_SUPPRESSED_FROM_DISCOVERY);
+  }
+
+  private void addCount(JsonNode target, JsonNode source, String recordType, String fieldName) {
+    var targetCounts = target.withObject("/" + RECORD_COUNTS + "/" + recordType);
+    var sourceCounts = getNode(source, RECORD_COUNTS, recordType);
+    targetCounts.put(fieldName, intValue(targetCounts, fieldName) + intValue(sourceCounts, fieldName));
+  }
+
+  private void mergeAggregateScope(JsonNode target, JsonNode source, String scope) {
+    Comparator<JsonNode> namedValueComparator = Comparator
+        .comparing((JsonNode node) -> stringValue(node, NAME), Comparator.nullsLast(String::compareTo))
+        .thenComparing(this::namedValueKey);
+    mergeEffectiveShelvingOrder(target, source, scope);
+    mergeArray(target, source, "/" + AGGREGATES + "/" + scope, ELECTRONIC_ACCESS,
+        this::electronicAccessKey, null);
+    mergeArray(target, source, "/" + AGGREGATES + "/" + scope + "/" + REFERENCE_VALUES, ITEM_MATERIAL_TYPES,
+        this::namedValueKey, namedValueComparator);
+  }
+
+  private void mergeEffectiveShelvingOrder(JsonNode target, JsonNode source, String scope) {
+    var targetFields = target.withObject("/" + AGGREGATES + "/" + scope + "/" + ITEM_DERIVED_FIELDS);
+    var targetValue = stringValue(targetFields, EFFECTIVE_SHELVING_ORDER);
+    var sourceValue = stringValue(getNode(source, AGGREGATES, scope, ITEM_DERIVED_FIELDS), EFFECTIVE_SHELVING_ORDER);
+    var mergedValue = firstShelvingOrder(targetValue, sourceValue);
+    if (mergedValue != null) {
+      targetFields.put(EFFECTIVE_SHELVING_ORDER, mergedValue);
+    }
+  }
+
+  private String firstShelvingOrder(String value1, String value2) {
+    if (value1 == null) {
+      return value2;
+    }
+    if (value2 == null) {
+      return value1;
+    }
+    return value1.compareTo(value2) <= 0 ? value1 : value2;
+  }
+
+  private void mergeArray(JsonNode target, JsonNode source, String parentPointer, String arrayName,
+      Function<JsonNode, String> keyProvider, Comparator<JsonNode> comparator) {
+    var merged = new LinkedHashMap<String, JsonNode>();
+    addArrayValues(merged, getNode(target.withObject(parentPointer), arrayName), keyProvider);
+    addArrayValues(merged, getNode(source, path(parentPointer, arrayName)), keyProvider);
+
+    var values = new ArrayList<>(merged.values());
+    if (comparator != null) {
+      values.sort(comparator);
+    }
+
+    var mergedArray = JsonNodeFactory.instance.arrayNode();
+    values.forEach(mergedArray::add);
+    target.withObject(parentPointer).set(arrayName, mergedArray);
+  }
+
+  private void addArrayValues(Map<String, JsonNode> valuesByKey, JsonNode arrayNode,
+      Function<JsonNode, String> keyProvider) {
+    if (!(arrayNode instanceof ArrayNode values)) {
+      return;
+    }
+    for (JsonNode value : values.elements()) {
+      valuesByKey.putIfAbsent(keyProvider.apply(value), value);
+    }
+  }
+
+  private String electronicAccessKey(JsonNode electronicAccess) {
+    var uri = stringValue(electronicAccess, URI);
+    return uri == null ? electronicAccess.toString() : uri;
+  }
+
+  private String namedValueKey(JsonNode namedValue) {
+    var id = stringValue(namedValue, ID_FIELD);
+    return id == null ? namedValue.toString() : id;
+  }
+
+  private String[] path(String parentPointer, String fieldName) {
+    var path = parentPointer.substring(1) + "/" + fieldName;
+    return path.split("/");
+  }
+
+  private JsonNode getNode(JsonNode node, String... fieldNames) {
+    var current = node;
+    for (String fieldName : fieldNames) {
+      if (current == null) {
+        return null;
+      }
+      current = current.get(fieldName);
+    }
+    return current;
+  }
+
+  private int intValue(JsonNode node, String fieldName) {
+    var value = node == null ? null : node.get(fieldName);
+    return value == null ? 0 : value.asInt();
+  }
+
+  private boolean booleanValue(JsonNode node, String fieldName) {
+    var value = node == null ? null : node.get(fieldName);
+    return value != null && value.asBoolean();
+  }
+
+  private String stringValue(JsonNode node, String fieldName) {
+    var value = node == null ? null : node.get(fieldName);
+    if (value == null || value.isNull()) {
+      return null;
+    }
+    var stringValue = value.asString();
+    return stringValue == null || stringValue.isBlank() ? null : stringValue;
   }
 
   private RequestQueryParameters getRequestQueryParams(List<String> instanceIds) {

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -27,6 +27,7 @@ import org.folio.edge.inventory.models.InstanceTenants;
 import org.folio.edge.inventory.service.mapper.RequestQueryParametersMapper;
 import org.folio.edge.inventory.util.JsonNodeUtil;
 import org.folio.edge.inventory.util.QueryUtil;
+import org.folio.inventory.domain.dto.FacetResponseFacetsHoldingsTenantIdValuesInner;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.stereotype.Service;
@@ -48,6 +49,7 @@ public class EcsInventoryService {
   private static final String IS_BOUND_WITH = "isBoundWith";
   private static final String ITEM_DERIVED_FIELDS = "itemDerivedFields";
   private static final String ITEM_MATERIAL_TYPES = "itemMaterialTypes";
+  private static final char JSON_POINTER_SEPARATOR = '/';
   private static final String NAME = "name";
   private static final String NOT_SUPPRESSED_FROM_DISCOVERY_RECORDS = "notSuppressedFromDiscoveryRecords";
   private static final String RECORD_COUNTS = "recordCounts";
@@ -71,7 +73,7 @@ public class EcsInventoryService {
     var effectiveTenantId = effectiveTenantId(tenantId);
     var userTenants = userClient.getUserTenants();
     if (userTenants.getTotalRecords() > 0) {
-      return effectiveTenantId != null && effectiveTenantId.equals(userTenants.getUserTenants().get(0).getCentralTenantId());
+      return effectiveTenantId != null && effectiveTenantId.equals(userTenants.getUserTenants().getFirst().getCentralTenantId());
     }
     return false;
   }
@@ -113,7 +115,7 @@ public class EcsInventoryService {
   private List<String> getInstanceIdsFromView(JsonNode instanceView) {
     var instanceIds = new ArrayList<String>();
     instanceView.withArray(INSTANCES).elements()
-        .forEach((instance) -> instanceIds.add(instance.get(INSTANCE_ID).asString()));
+        .forEach(instance -> instanceIds.add(instance.get(INSTANCE_ID).asString()));
     return instanceIds;
   }
 
@@ -190,9 +192,11 @@ public class EcsInventoryService {
   }
 
   private void addCount(JsonNode target, JsonNode source, String recordType, String fieldName) {
-    var targetCounts = target.withObject("/" + RECORD_COUNTS + "/" + recordType);
+    var targetCounts = target.withObject(jsonPointer(RECORD_COUNTS, recordType));
     var sourceCounts = getNode(source, RECORD_COUNTS, recordType);
-    targetCounts.put(fieldName, intValue(targetCounts, fieldName) + intValue(sourceCounts, fieldName));
+    if (targetCounts != null) {
+      targetCounts.put(fieldName, intValue(targetCounts, fieldName) + intValue(sourceCounts, fieldName));
+    }
   }
 
   private void mergeAggregateScope(JsonNode target, JsonNode source, String scope) {
@@ -200,19 +204,21 @@ public class EcsInventoryService {
         .comparing((JsonNode node) -> stringValue(node, NAME), Comparator.nullsLast(String::compareTo))
         .thenComparing(this::namedValueKey);
     mergeEffectiveShelvingOrder(target, source, scope);
-    mergeArray(target, source, "/" + AGGREGATES + "/" + scope, ELECTRONIC_ACCESS,
+    mergeArray(target, source, jsonPointer(AGGREGATES, scope), ELECTRONIC_ACCESS,
         this::electronicAccessKey, null);
-    mergeArray(target, source, "/" + AGGREGATES + "/" + scope + "/" + REFERENCE_VALUES, ITEM_MATERIAL_TYPES,
+    mergeArray(target, source, jsonPointer(AGGREGATES, scope, REFERENCE_VALUES), ITEM_MATERIAL_TYPES,
         this::namedValueKey, namedValueComparator);
   }
 
   private void mergeEffectiveShelvingOrder(JsonNode target, JsonNode source, String scope) {
-    var targetFields = target.withObject("/" + AGGREGATES + "/" + scope + "/" + ITEM_DERIVED_FIELDS);
-    var targetValue = stringValue(targetFields, EFFECTIVE_SHELVING_ORDER);
-    var sourceValue = stringValue(getNode(source, AGGREGATES, scope, ITEM_DERIVED_FIELDS), EFFECTIVE_SHELVING_ORDER);
-    var mergedValue = firstShelvingOrder(targetValue, sourceValue);
-    if (mergedValue != null) {
-      targetFields.put(EFFECTIVE_SHELVING_ORDER, mergedValue);
+    var targetFields = target.withObject(jsonPointer(AGGREGATES, scope, ITEM_DERIVED_FIELDS));
+    if (targetFields != null) {
+      var targetValue = stringValue(targetFields, EFFECTIVE_SHELVING_ORDER);
+      var sourceValue = stringValue(getNode(source, AGGREGATES, scope, ITEM_DERIVED_FIELDS), EFFECTIVE_SHELVING_ORDER);
+      var mergedValue = firstShelvingOrder(targetValue, sourceValue);
+      if (mergedValue != null) {
+        targetFields.put(EFFECTIVE_SHELVING_ORDER, mergedValue);
+      }
     }
   }
 
@@ -229,7 +235,8 @@ public class EcsInventoryService {
   private void mergeArray(JsonNode target, JsonNode source, String parentPointer, String arrayName,
       Function<JsonNode, String> keyProvider, Comparator<JsonNode> comparator) {
     var merged = new LinkedHashMap<String, JsonNode>();
-    addArrayValues(merged, getNode(target.withObject(parentPointer), arrayName), keyProvider);
+    var targetParent = target.withObject(parentPointer);
+    addArrayValues(merged, getNode(targetParent, arrayName), keyProvider);
     addArrayValues(merged, getNode(source, path(parentPointer, arrayName)), keyProvider);
 
     var values = new ArrayList<>(merged.values());
@@ -239,7 +246,9 @@ public class EcsInventoryService {
 
     var mergedArray = JsonNodeFactory.instance.arrayNode();
     values.forEach(mergedArray::add);
-    target.withObject(parentPointer).set(arrayName, mergedArray);
+    if (targetParent != null) {
+      targetParent.set(arrayName, mergedArray);
+    }
   }
 
   private void addArrayValues(Map<String, JsonNode> valuesByKey, JsonNode arrayNode,
@@ -263,8 +272,12 @@ public class EcsInventoryService {
   }
 
   private String[] path(String parentPointer, String fieldName) {
-    var path = parentPointer.substring(1) + "/" + fieldName;
-    return path.split("/");
+    var path = parentPointer.substring(1) + JSON_POINTER_SEPARATOR + fieldName;
+    return path.split(String.valueOf(JSON_POINTER_SEPARATOR));
+  }
+
+  private String jsonPointer(String... pathSegments) {
+    return JSON_POINTER_SEPARATOR + String.join(String.valueOf(JSON_POINTER_SEPARATOR), pathSegments);
   }
 
   private JsonNode getNode(JsonNode node, String... fieldNames) {
@@ -308,11 +321,13 @@ public class EcsInventoryService {
 
   private InstanceTenants getInstanceTenants(String instanceId) {
     var response = searchClient.getInstanceFacet(FACET, "id==" + instanceId);
-    if (response.getFacets().getHoldingsTenantId().getTotalRecords() == 0) {
+    var holdingsTenantId = response.getFacets().getHoldingsTenantId();
+    var totalRecords = holdingsTenantId == null ? null : holdingsTenantId.getTotalRecords();
+    if (totalRecords == null || totalRecords == 0) {
       return new InstanceTenants(instanceId, Collections.<String>emptyList());
     }
-    var tenantIds = response.getFacets().getHoldingsTenantId().getValues()
-        .stream().map(value -> value.getId()).toList();
+    var tenantIds = holdingsTenantId.getValues()
+        .stream().map(FacetResponseFacetsHoldingsTenantIdValuesInner::getId).toList();
     return new InstanceTenants(instanceId, tenantIds);
   }
 

--- a/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/EcsInventoryService.java
@@ -254,16 +254,25 @@ public class EcsInventoryService {
       return;
     }
     for (JsonNode value : values.elements()) {
+      if (value == null || value.isNull()) {
+        continue;
+      }
       valuesByKey.putIfAbsent(keyProvider.apply(value), value);
     }
   }
 
   private String electronicAccessKey(JsonNode electronicAccess) {
+    if (electronicAccess == null || electronicAccess.isNull()) {
+      return "";
+    }
     var uri = stringValue(electronicAccess, URI);
     return uri == null ? electronicAccess.toString() : uri;
   }
 
   private String namedValueKey(JsonNode namedValue) {
+    if (namedValue == null || namedValue.isNull()) {
+      return "";
+    }
     var id = stringValue(namedValue, ID_FIELD);
     return id == null ? namedValue.toString() : id;
   }

--- a/src/main/java/org/folio/edge/inventory/service/InventoryService.java
+++ b/src/main/java/org/folio/edge/inventory/service/InventoryService.java
@@ -17,6 +17,10 @@ public class InventoryService {
     return inventoryClient.getInstance(instanceId, lang).toString();
   }
 
+  public String getInstanceSummary(String instanceId) {
+    return inventoryClient.getInstanceSummary(instanceId).toString();
+  }
+
   public String getInstancesByQuery(RequestQueryParameters requestQueryParameters) {
     var requestQueryParametersMap = requestQueryParametersMapper.toMap(requestQueryParameters);
     return inventoryClient.getInstancesByQuery(requestQueryParametersMap).toString();

--- a/src/main/resources/swagger.api/edge-inventory.yaml
+++ b/src/main/resources/swagger.api/edge-inventory.yaml
@@ -37,6 +37,33 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
 
+  /inventory/instances/{instanceId}/summary:
+    get:
+      tags:
+        - instances
+      operationId: getInstanceSummary
+      summary: Retrieve inventory instance summary by id from folio mod-inventory-storage
+      description: Retrieve inventory instance summary by id from folio mod-inventory-storage
+      parameters:
+        - $ref: '#/components/parameters/x-okapi-tenant-header'
+        - $ref: '#/components/parameters/x-okapi-token-header'
+        - $ref: '#/components/parameters/instance-id'
+      responses:
+        '200':
+          description: |
+            Calls the mod-inventory-storage GET /instance-storage/instances/{id}/summary API and returns the result as-is. \
+            In ECS central tenant mode, summaries from tenants with holdings are merged into a single response.
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '404':
+          $ref: '#/components/responses/notFoundResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
+
   /inventory/instances:
     get:
       operationId: getInstancesByQuery

--- a/src/test/java/org/folio/edge/inventory/TestConstants.java
+++ b/src/test/java/org/folio/edge/inventory/TestConstants.java
@@ -9,6 +9,9 @@ public class TestConstants {
   public static final String GET_EDGE_IDENTIFIER_TYPES_BY_VALID_URL = StringUtils
       .join(OKAPI_URL, "/inventory/identifier-types");
   public static final String INSTANCE_RESPONSE_PATH = "__files/responses/instance_response.json";
+  public static final String INSTANCE_SUMMARY_RESPONSE_PATH = "__files/responses/instance_summary_response.json";
+  public static final String INSTANCE_SUMMARY_MEMBER_1_RESPONSE_PATH = "__files/responses/instance_summary_member_1_response.json";
+  public static final String INSTANCE_SUMMARY_MEMBER_2_RESPONSE_PATH = "__files/responses/instance_summary_member_2_response.json";
   public static final String AUTHORITY_RESPONSE_PATH = "__files/responses/authority_response.json";
   public static final String IDENTIFIER_TYPES_RESPONSE_PATH = "__files/responses/identifier_types_response.json";
   public static final String LOCATIONS_RESPONSE_PATH = "__files/responses/locations_response.json";
@@ -39,6 +42,8 @@ public class TestConstants {
   public static final String SOURCE_RECORD_RESPONSE_PATH ="__files/responses/source-records.json";
   public static final String AUTHORITY_SOURCE_RECORD_RESPONSE_PATH = "__files/responses/authority_source_records.json";
   public static final String HOLDINGS_FACET_RESPONSE_PATH = "__files/responses/holdings_facet_response.json";
+  public static final String HOLDINGS_FACET_WITH_TWO_TENANTS_RESPONSE_PATH =
+      "__files/responses/holdings_facet_with_two_tenants_response.json";
   public static final String HOLDING_RESPONSE_PATH = "__files/responses/holding_response.json";
   public static final String USER_TENANTS_RESPONSE_PATH = "__files/responses/user_tenants_response.json";
   public static final String USER_TENANTS_NON_CONSORTIA_RESPONSE_PATH = "__files/responses/user_tenants_non_consortia_response.json";
@@ -60,6 +65,7 @@ public class TestConstants {
   public static final String LANG_PARAM_INVALID_VALUE = "invalid";
   public static final String VALID_INSTANCE_ID = "e6bc03c6-c137-4221-b679-a7c5c31f986c";
   public static final String INSTANCE_BY_VALID_INSTANCE_ID_URL = "/inventory/instances/e6bc03c6-c137-4221-b679-a7c5c31f986c";
+  public static final String INSTANCE_SUMMARY_BY_VALID_INSTANCE_ID_URL = "/inventory/instances/e6bc03c6-c137-4221-b679-a7c5c31f986c/summary";
   public static final String INSTANCE_BY_INVALID_INSTANCE_ID_URL = "/inventory/instances/invalidid";
   public static final String INSTANCE_BY_NOT_FOUND_INSTANCE_ID_URL = "/inventory/instances/b48afa82-779c-4460-86bd-de78b6ab866f";
   public static final String VALID_AUTHORITY_ID = "9eba0866-8195-457c-ac72-dbfc279cc496";

--- a/src/test/java/org/folio/edge/inventory/TestConstants.java
+++ b/src/test/java/org/folio/edge/inventory/TestConstants.java
@@ -12,6 +12,10 @@ public class TestConstants {
   public static final String INSTANCE_SUMMARY_RESPONSE_PATH = "__files/responses/instance_summary_response.json";
   public static final String INSTANCE_SUMMARY_MEMBER_1_RESPONSE_PATH = "__files/responses/instance_summary_member_1_response.json";
   public static final String INSTANCE_SUMMARY_MEMBER_2_RESPONSE_PATH = "__files/responses/instance_summary_member_2_response.json";
+  public static final String INSTANCE_SUMMARY_SPARSE_CENTRAL_RESPONSE_PATH =
+      "__files/responses/instance_summary_sparse_central_response.json";
+  public static final String INSTANCE_SUMMARY_SPARSE_MEMBER_RESPONSE_PATH =
+      "__files/responses/instance_summary_sparse_member_response.json";
   public static final String AUTHORITY_RESPONSE_PATH = "__files/responses/authority_response.json";
   public static final String IDENTIFIER_TYPES_RESPONSE_PATH = "__files/responses/identifier_types_response.json";
   public static final String LOCATIONS_RESPONSE_PATH = "__files/responses/locations_response.json";
@@ -42,6 +46,7 @@ public class TestConstants {
   public static final String SOURCE_RECORD_RESPONSE_PATH ="__files/responses/source-records.json";
   public static final String AUTHORITY_SOURCE_RECORD_RESPONSE_PATH = "__files/responses/authority_source_records.json";
   public static final String HOLDINGS_FACET_RESPONSE_PATH = "__files/responses/holdings_facet_response.json";
+  public static final String HOLDINGS_FACET_EMPTY_RESPONSE_PATH = "__files/responses/holdings_facet_empty_response.json";
   public static final String HOLDINGS_FACET_WITH_TWO_TENANTS_RESPONSE_PATH =
       "__files/responses/holdings_facet_with_two_tenants_response.json";
   public static final String HOLDING_RESPONSE_PATH = "__files/responses/holding_response.json";

--- a/src/test/java/org/folio/edge/inventory/controller/EcsInventoryControllerIT.java
+++ b/src/test/java/org/folio/edge/inventory/controller/EcsInventoryControllerIT.java
@@ -10,6 +10,7 @@ import static org.folio.edge.inventory.TestConstants.GET_LOCATION_BY_ID_URL;
 import static org.folio.edge.inventory.TestConstants.GET_MATERIAL_TYPES_URL;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_URL;
 import static org.folio.edge.inventory.TestConstants.INSTITUTION_ID;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_BY_VALID_INSTANCE_ID_URL;
 import static org.folio.edge.inventory.TestConstants.LIBRARY_ID;
 import static org.folio.edge.inventory.TestConstants.LOCATION_ID;
 import static org.hamcrest.Matchers.hasSize;
@@ -30,6 +31,25 @@ class EcsInventoryControllerIT extends BaseIntegrationTests {
 
   @Autowired
   private MockMvc mockMvc;
+
+  @Test
+  void getInstanceSummary_shouldReturnMergedSummaryFromTenantsWithHoldings() throws Exception {
+    doGet(mockMvc, INSTANCE_SUMMARY_BY_VALID_INSTANCE_ID_URL, true)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("instance.title", is("Central summary instance")))
+        .andExpect(jsonPath("isBoundWith", is(true)))
+        .andExpect(jsonPath("recordCounts.holdings.total", is(4)))
+        .andExpect(jsonPath("recordCounts.holdings.suppressedFromDiscovery", is(1)))
+        .andExpect(jsonPath("recordCounts.holdings.notSuppressedFromDiscovery", is(3)))
+        .andExpect(jsonPath("recordCounts.items.total", is(8)))
+        .andExpect(jsonPath("recordCounts.items.suppressedFromDiscovery", is(1)))
+        .andExpect(jsonPath("recordCounts.items.suppressedByHoldings", is(1)))
+        .andExpect(jsonPath("recordCounts.items.suppressedFromDiscoveryOrByHoldings", is(2)))
+        .andExpect(jsonPath("recordCounts.items.notSuppressedFromDiscovery", is(6)))
+        .andExpect(jsonPath("aggregates.allRecords.itemDerivedFields.effectiveShelvingOrder", is("CN 001")))
+        .andExpect(jsonPath("aggregates.allRecords.electronicAccess", hasSize(3)))
+        .andExpect(jsonPath("aggregates.allRecords.referenceValues.itemMaterialTypes", hasSize(3)));
+  }
 
   @Test
   void getInventoryViewInstances_shouldReturnInventoryViewInstancesWithHoldingsFromMemberTenant() throws Exception {

--- a/src/test/java/org/folio/edge/inventory/controller/InventoryControllerIT.java
+++ b/src/test/java/org/folio/edge/inventory/controller/InventoryControllerIT.java
@@ -38,6 +38,7 @@ import static org.folio.edge.inventory.TestConstants.INSTANCES_WITH_QUERY_URL_NO
 import static org.folio.edge.inventory.TestConstants.INSTANCE_BY_INVALID_INSTANCE_ID_URL;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_BY_NOT_FOUND_INSTANCE_ID_URL;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_BY_VALID_INSTANCE_ID_URL;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_BY_VALID_INSTANCE_ID_URL;
 import static org.folio.edge.inventory.TestConstants.LANG_PARAM_INVALID_VALUE;
 import static org.folio.edge.inventory.TestConstants.LANG_PARAM_NAME;
 import static org.folio.edge.inventory.TestConstants.LANG_PARAM_VALID_VALUE;
@@ -80,6 +81,16 @@ class InventoryControllerIT extends BaseIntegrationTests {
         .andExpect(
             jsonPath("title", is("Organisations- und Prozessentwicklung Harald Augustin (Hrsg.)")))
         .andExpect(jsonPath("source", is("FOLIO")));
+  }
+
+  @Test
+  void getInstanceSummary_shouldReturnInstanceSummary_whenInstanceIdValid() throws Exception {
+    doGet(mockMvc, INSTANCE_SUMMARY_BY_VALID_INSTANCE_ID_URL)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("instance.id", is("e6bc03c6-c137-4221-b679-a7c5c31f986c")))
+        .andExpect(jsonPath("recordCounts.holdings.total", is(1)))
+        .andExpect(jsonPath("recordCounts.items.total", is(1)))
+        .andExpect(jsonPath("aggregates.allRecords.itemDerivedFields.effectiveShelvingOrder", is("CN 002")));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
@@ -4,15 +4,21 @@ import static org.folio.edge.inventory.TestConstants.CENTRAL_TEST_TENANT;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_WITHOUT_HOLDINGS_PATH;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_WITH_HOLDINGS_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDINGS_FACET_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.HOLDINGS_FACET_WITH_TWO_TENANTS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDINGS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDING_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_MEMBER_1_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_MEMBER_2_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.ITEMS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.USER_TENANTS_NON_CONSORTIA_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.USER_TENANTS_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.VALID_INSTANCE_ID;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.HOLDINGS_RECORDS;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.INSTANCES;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.ITEMS;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.TOTAL_RECORDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,9 +26,15 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.SneakyThrows;
 import org.folio.edge.inventory.TestConstants;
 import org.folio.edge.inventory.TestUtil;
@@ -35,6 +47,7 @@ import org.folio.inventory.domain.dto.HoldingResponse;
 import org.folio.inventory.domain.dto.RequestQueryParameters;
 import org.folio.inventory.domain.dto.UserTenants;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,6 +80,43 @@ public class EcsInventoryServiceTest {
     var emptyQueryMap = Collections.emptyMap();
     lenient().doReturn(emptyQueryMap)
         .when(requestQueryParametersMapper).toMap(any(RequestQueryParameters.class));
+  }
+
+  @Test
+  @SneakyThrows
+  void getEcsInstanceSummary_shouldReturnMergedSummaryFromTenantsWithHoldings() {
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(folioExecutionContext.getAllHeaders()).thenReturn(okapiHeaders(CENTRAL_TEST_TENANT));
+    when(folioExecutionContext.getOkapiHeaders()).thenReturn(okapiHeaders(CENTRAL_TEST_TENANT));
+    when(inventoryClient.getInstanceSummary(VALID_INSTANCE_ID))
+        .thenReturn(getJsonNode(INSTANCE_SUMMARY_RESPONSE_PATH))
+        .thenReturn(getJsonNode(INSTANCE_SUMMARY_MEMBER_1_RESPONSE_PATH))
+        .thenReturn(getJsonNode(INSTANCE_SUMMARY_MEMBER_2_RESPONSE_PATH));
+    var facetResponse = objectMapper.readValue(
+        TestUtil.readFileContentFromResources(HOLDINGS_FACET_WITH_TWO_TENANTS_RESPONSE_PATH), FacetResponse.class);
+    when(searchClient.getInstanceFacet(eq(ecsInventoryService.FACET), anyString()))
+        .thenReturn(facetResponse);
+
+    var response = objectMapper.readTree(
+        ecsInventoryService.getEcsInstanceSummary(VALID_INSTANCE_ID, CENTRAL_TEST_TENANT));
+
+    verify(inventoryClient, times(3)).getInstanceSummary(VALID_INSTANCE_ID);
+    assertEquals("Central summary instance", response.get("instance").get("title").asString());
+    assertTrue(response.get("isBoundWith").asBoolean());
+    assertEquals(4, response.get("recordCounts").get("holdings").get("total").asInt());
+    assertEquals(1, response.get("recordCounts").get("holdings").get("suppressedFromDiscovery").asInt());
+    assertEquals(3, response.get("recordCounts").get("holdings").get("notSuppressedFromDiscovery").asInt());
+    assertEquals(8, response.get("recordCounts").get("items").get("total").asInt());
+    assertEquals(1, response.get("recordCounts").get("items").get("suppressedFromDiscovery").asInt());
+    assertEquals(1, response.get("recordCounts").get("items").get("suppressedByHoldings").asInt());
+    assertEquals(2, response.get("recordCounts").get("items").get("suppressedFromDiscoveryOrByHoldings").asInt());
+    assertEquals(6, response.get("recordCounts").get("items").get("notSuppressedFromDiscovery").asInt());
+
+    var allRecords = response.get("aggregates").get("allRecords");
+    assertEquals("CN 001", allRecords.get("itemDerivedFields").get("effectiveShelvingOrder").asString());
+    assertEquals(3, allRecords.get("electronicAccess").size());
+    assertEquals(3, allRecords.get("referenceValues").get("itemMaterialTypes").size());
+    assertEquals("book", allRecords.get("referenceValues").get("itemMaterialTypes").get(0).get("name").asString());
   }
 
   @Test
@@ -176,5 +226,13 @@ public class EcsInventoryServiceTest {
 
   private JsonNode getJsonNode(String resourcePath) {
     return objectMapper.readTree(TestUtil.readFileContentFromResources(resourcePath));
+  }
+
+  private Map<String, Collection<String>> okapiHeaders(String tenantId) {
+    var headers = new HashMap<String, Collection<String>>();
+    headers.put(XOkapiHeaders.TENANT, List.of(tenantId));
+    headers.put(XOkapiHeaders.URL, List.of("http://localhost"));
+    headers.put(XOkapiHeaders.TOKEN, List.of("token"));
+    return headers;
   }
 }

--- a/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
@@ -52,6 +52,7 @@ import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.JsonNode;
@@ -71,13 +72,12 @@ public class EcsInventoryServiceTest {
   @Mock
   private RequestQueryParametersMapper requestQueryParametersMapper;
 
+  @InjectMocks
   private EcsInventoryService ecsInventoryService;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @BeforeEach
   void setUp() {
-    ecsInventoryService = new EcsInventoryService(usersClient, inventoryClient, searchClient,
-        folioExecutionContext, requestQueryParametersMapper);
     var emptyQueryMap = Collections.emptyMap();
     lenient().doReturn(emptyQueryMap)
         .when(requestQueryParametersMapper).toMap(any(RequestQueryParameters.class));

--- a/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
@@ -20,6 +20,7 @@ import static org.folio.edge.inventory.models.InventoryViewJsonFields.ITEMS;
 import static org.folio.edge.inventory.models.InventoryViewJsonFields.TOTAL_RECORDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -115,8 +116,31 @@ public class EcsInventoryServiceTest {
     var allRecords = response.get("aggregates").get("allRecords");
     assertEquals("CN 001", allRecords.get("itemDerivedFields").get("effectiveShelvingOrder").asString());
     assertEquals(3, allRecords.get("electronicAccess").size());
+    assertEquals("https://example.org/central", allRecords.get("electronicAccess").get(0).get("uri").asString());
+    assertEquals("https://example.org/member-one", allRecords.get("electronicAccess").get(1).get("uri").asString());
+    assertEquals("https://example.org/member-two", allRecords.get("electronicAccess").get(2).get("uri").asString());
     assertEquals(3, allRecords.get("referenceValues").get("itemMaterialTypes").size());
     assertEquals("book", allRecords.get("referenceValues").get("itemMaterialTypes").get(0).get("name").asString());
+  }
+
+  @Test
+  @SneakyThrows
+  void getEcsInstanceSummary_shouldFailWhenMemberTenantSummaryFails() {
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(folioExecutionContext.getAllHeaders()).thenReturn(okapiHeaders(CENTRAL_TEST_TENANT));
+    when(folioExecutionContext.getOkapiHeaders()).thenReturn(okapiHeaders(CENTRAL_TEST_TENANT));
+    when(inventoryClient.getInstanceSummary(VALID_INSTANCE_ID))
+        .thenReturn(getJsonNode(INSTANCE_SUMMARY_RESPONSE_PATH))
+        .thenThrow(new IllegalStateException("member summary failed"));
+    var facetResponse = objectMapper.readValue(
+        TestUtil.readFileContentFromResources(HOLDINGS_FACET_RESPONSE_PATH), FacetResponse.class);
+    when(searchClient.getInstanceFacet(eq(ecsInventoryService.FACET), anyString()))
+        .thenReturn(facetResponse);
+
+    assertThrows(RuntimeException.class, () ->
+        ecsInventoryService.getEcsInstanceSummary(VALID_INSTANCE_ID, CENTRAL_TEST_TENANT));
+
+    verify(inventoryClient, times(2)).getInstanceSummary(VALID_INSTANCE_ID);
   }
 
   @Test

--- a/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/EcsInventoryServiceTest.java
@@ -4,12 +4,15 @@ import static org.folio.edge.inventory.TestConstants.CENTRAL_TEST_TENANT;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_WITHOUT_HOLDINGS_PATH;
 import static org.folio.edge.inventory.TestConstants.GET_VIEW_INSTANCES_WITH_HOLDINGS_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDINGS_FACET_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.HOLDINGS_FACET_EMPTY_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDINGS_FACET_WITH_TWO_TENANTS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDINGS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.HOLDING_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_MEMBER_1_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_MEMBER_2_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_SPARSE_CENTRAL_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_SPARSE_MEMBER_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.ITEMS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.USER_TENANTS_NON_CONSORTIA_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.USER_TENANTS_RESPONSE_PATH;
@@ -121,6 +124,53 @@ public class EcsInventoryServiceTest {
     assertEquals("https://example.org/member-two", allRecords.get("electronicAccess").get(2).get("uri").asString());
     assertEquals(3, allRecords.get("referenceValues").get("itemMaterialTypes").size());
     assertEquals("book", allRecords.get("referenceValues").get("itemMaterialTypes").get(0).get("name").asString());
+  }
+
+  @Test
+  @SneakyThrows
+  void getEcsInstanceSummary_shouldReturnCentralSummaryWhenFacetHasNoHoldings() {
+    when(inventoryClient.getInstanceSummary(VALID_INSTANCE_ID))
+        .thenReturn(getJsonNode(INSTANCE_SUMMARY_RESPONSE_PATH));
+    when(searchClient.getInstanceFacet(eq(ecsInventoryService.FACET), anyString()))
+        .thenReturn(getFacetResponse(HOLDINGS_FACET_EMPTY_RESPONSE_PATH));
+
+    var response = objectMapper.readTree(
+        ecsInventoryService.getEcsInstanceSummary(VALID_INSTANCE_ID, CENTRAL_TEST_TENANT));
+
+    verify(inventoryClient).getInstanceSummary(VALID_INSTANCE_ID);
+    assertEquals("Central summary instance", response.get("instance").get("title").asString());
+    assertEquals(1, response.get("recordCounts").get("holdings").get("total").asInt());
+  }
+
+  @Test
+  @SneakyThrows
+  void getEcsInstanceSummary_shouldMergeSparseSummaryData() {
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(folioExecutionContext.getAllHeaders()).thenReturn(okapiHeaders(CENTRAL_TEST_TENANT));
+    when(folioExecutionContext.getOkapiHeaders()).thenReturn(okapiHeaders(CENTRAL_TEST_TENANT));
+    when(inventoryClient.getInstanceSummary(VALID_INSTANCE_ID))
+        .thenReturn(getJsonNode(INSTANCE_SUMMARY_SPARSE_CENTRAL_RESPONSE_PATH))
+        .thenReturn(getJsonNode(INSTANCE_SUMMARY_SPARSE_MEMBER_RESPONSE_PATH));
+    var facetResponse = getFacetResponse(HOLDINGS_FACET_RESPONSE_PATH);
+    when(searchClient.getInstanceFacet(eq(ecsInventoryService.FACET), anyString()))
+        .thenReturn(facetResponse);
+
+    var response = objectMapper.readTree(
+        ecsInventoryService.getEcsInstanceSummary(VALID_INSTANCE_ID, CENTRAL_TEST_TENANT));
+
+    var allRecords = response.get("aggregates").get("allRecords");
+    assertEquals("CN 010", allRecords.get("itemDerivedFields").get("effectiveShelvingOrder").asString());
+    assertEquals(1, allRecords.get("electronicAccess").size());
+    assertEquals("Blank URI", allRecords.get("electronicAccess").get(0).get("linkText").asString());
+    assertEquals(1, allRecords.get("referenceValues").get("itemMaterialTypes").size());
+    assertEquals("unknown material",
+        allRecords.get("referenceValues").get("itemMaterialTypes").get(0).get("name").asString());
+
+    var notSuppressedRecords = response.get("aggregates").get("notSuppressedFromDiscoveryRecords");
+    assertEquals("CN 020",
+        notSuppressedRecords.get("itemDerivedFields").get("effectiveShelvingOrder").asString());
+    assertEquals(1, response.get("recordCounts").get("holdings").get("total").asInt());
+    assertFalse(response.get("isBoundWith").asBoolean());
   }
 
   @Test
@@ -250,6 +300,10 @@ public class EcsInventoryServiceTest {
 
   private JsonNode getJsonNode(String resourcePath) {
     return objectMapper.readTree(TestUtil.readFileContentFromResources(resourcePath));
+  }
+
+  private FacetResponse getFacetResponse(String resourcePath) {
+    return objectMapper.readValue(TestUtil.readFileContentFromResources(resourcePath), FacetResponse.class);
   }
 
   private Map<String, Collection<String>> okapiHeaders(String tenantId) {

--- a/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
@@ -52,6 +52,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.JsonNode;
@@ -68,6 +69,7 @@ class InventoryServiceTest {
   private static final String TOTAL_RECORDS = "totalRecords";
   private static final String EFFECTIVE_SHELVING_ORDER = "effectiveShelvingOrder";
 
+  @InjectMocks
   private InventoryService inventoryService;
   @Mock
   private InventoryClient inventoryClient;
@@ -76,7 +78,6 @@ class InventoryServiceTest {
 
   @BeforeEach
   void setUp() {
-    inventoryService = new InventoryService(inventoryClient, requestQueryParametersMapper);
     var emptyQueryMap = Collections.emptyMap();
     lenient().doReturn(emptyQueryMap)
         .when(requestQueryParametersMapper).toMap(any(RequestQueryParameters.class));

--- a/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/org/folio/edge/inventory/service/InventoryServiceTest.java
@@ -16,6 +16,7 @@ import static org.folio.edge.inventory.TestConstants.IDENTIFIER_TYPES_RESPONSE_P
 import static org.folio.edge.inventory.TestConstants.INSTANCE_FORMATS_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_NOTE_TYPES_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_RESPONSE_PATH;
+import static org.folio.edge.inventory.TestConstants.INSTANCE_SUMMARY_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTANCE_TYPES_RESPONSE_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTITUTION_BY_ID_PATH;
 import static org.folio.edge.inventory.TestConstants.INSTITUTION_ID;
@@ -95,6 +96,22 @@ class InventoryServiceTest {
     assertEquals("inst000000000027", actualInstance.get("hrid"));
     assertEquals("Organisations- und Prozessentwicklung Harald Augustin (Hrsg.)", actualInstance.get("title"));
     assertEquals("FOLIO", actualInstance.get(SOURCE));
+  }
+
+  @Test
+  void getInstanceSummaryById_shouldReturnInstanceSummary() throws JSONException {
+    when(inventoryClient
+        .getInstanceSummary(VALID_INSTANCE_ID))
+        .thenReturn(jsonNode(INSTANCE_SUMMARY_RESPONSE_PATH));
+
+    JSONObject actualSummary = new JSONObject(inventoryService.getInstanceSummary(VALID_INSTANCE_ID));
+
+    assertEquals(VALID_INSTANCE_ID, actualSummary.getJSONObject("instance").get(ID));
+    assertEquals(1, actualSummary.getJSONObject("recordCounts").getJSONObject("holdings").get("total"));
+    assertEquals("CN 002", actualSummary.getJSONObject("aggregates")
+        .getJSONObject("allRecords")
+        .getJSONObject("itemDerivedFields")
+        .get(EFFECTIVE_SHELVING_ORDER));
   }
 
   @Test

--- a/src/test/resources/__files/responses/holdings_facet_empty_response.json
+++ b/src/test/resources/__files/responses/holdings_facet_empty_response.json
@@ -1,0 +1,9 @@
+{
+  "facets": {
+    "holdings.tenantId": {
+      "values": [],
+      "totalRecords": 0
+    }
+  },
+  "totalRecords": 0
+}

--- a/src/test/resources/__files/responses/instance_summary_member_1_response.json
+++ b/src/test/resources/__files/responses/instance_summary_member_1_response.json
@@ -1,0 +1,81 @@
+{
+  "instance": {
+    "id": "e6bc03c6-c137-4221-b679-a7c5c31f986c",
+    "title": "Member one summary instance",
+    "source": "FOLIO"
+  },
+  "isBoundWith": false,
+  "recordCounts": {
+    "instance": {
+      "suppressedFromDiscovery": false
+    },
+    "holdings": {
+      "total": 2,
+      "suppressedFromDiscovery": 1,
+      "notSuppressedFromDiscovery": 1
+    },
+    "items": {
+      "total": 3,
+      "suppressedFromDiscovery": 1,
+      "suppressedByHoldings": 1,
+      "suppressedFromDiscoveryOrByHoldings": 2,
+      "notSuppressedFromDiscovery": 1
+    }
+  },
+  "aggregates": {
+    "allRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 001"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/central",
+          "linkText": "Central duplicate"
+        },
+        {
+          "uri": "https://example.org/member-one",
+          "linkText": "Member one"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "11111111-1111-4111-8111-111111111111",
+            "name": "book"
+          },
+          {
+            "id": "22222222-2222-4222-8222-222222222222",
+            "name": "journal"
+          }
+        ]
+      }
+    },
+    "notSuppressedFromDiscoveryRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 001"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/member-one",
+          "linkText": "Member one"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "22222222-2222-4222-8222-222222222222",
+            "name": "journal"
+          }
+        ]
+      }
+    }
+  },
+  "referenceValues": {
+    "instanceFormats": [],
+    "natureOfContentTerms": [],
+    "instanceType": {
+      "id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "name": "text"
+    }
+  }
+}

--- a/src/test/resources/__files/responses/instance_summary_member_1_response.json
+++ b/src/test/resources/__files/responses/instance_summary_member_1_response.json
@@ -6,9 +6,6 @@
   },
   "isBoundWith": false,
   "recordCounts": {
-    "instance": {
-      "suppressedFromDiscovery": false
-    },
     "holdings": {
       "total": 2,
       "suppressedFromDiscovery": 1,

--- a/src/test/resources/__files/responses/instance_summary_member_2_response.json
+++ b/src/test/resources/__files/responses/instance_summary_member_2_response.json
@@ -6,9 +6,6 @@
   },
   "isBoundWith": true,
   "recordCounts": {
-    "instance": {
-      "suppressedFromDiscovery": false
-    },
     "holdings": {
       "total": 1,
       "suppressedFromDiscovery": 0,

--- a/src/test/resources/__files/responses/instance_summary_member_2_response.json
+++ b/src/test/resources/__files/responses/instance_summary_member_2_response.json
@@ -1,0 +1,73 @@
+{
+  "instance": {
+    "id": "e6bc03c6-c137-4221-b679-a7c5c31f986c",
+    "title": "Member two summary instance",
+    "source": "FOLIO"
+  },
+  "isBoundWith": true,
+  "recordCounts": {
+    "instance": {
+      "suppressedFromDiscovery": false
+    },
+    "holdings": {
+      "total": 1,
+      "suppressedFromDiscovery": 0,
+      "notSuppressedFromDiscovery": 1
+    },
+    "items": {
+      "total": 4,
+      "suppressedFromDiscovery": 0,
+      "suppressedByHoldings": 0,
+      "suppressedFromDiscoveryOrByHoldings": 0,
+      "notSuppressedFromDiscovery": 4
+    }
+  },
+  "aggregates": {
+    "allRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 003"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/member-two",
+          "linkText": "Member two"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "33333333-3333-4333-8333-333333333333",
+            "name": "map"
+          }
+        ]
+      }
+    },
+    "notSuppressedFromDiscoveryRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 003"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/member-two",
+          "linkText": "Member two"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "33333333-3333-4333-8333-333333333333",
+            "name": "map"
+          }
+        ]
+      }
+    }
+  },
+  "referenceValues": {
+    "instanceFormats": [],
+    "natureOfContentTerms": [],
+    "instanceType": {
+      "id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "name": "text"
+    }
+  }
+}

--- a/src/test/resources/__files/responses/instance_summary_response.json
+++ b/src/test/resources/__files/responses/instance_summary_response.json
@@ -1,0 +1,78 @@
+{
+  "instance": {
+    "id": "e6bc03c6-c137-4221-b679-a7c5c31f986c",
+    "title": "Central summary instance",
+    "source": "FOLIO"
+  },
+  "isBoundWith": false,
+  "recordCounts": {
+    "instance": {
+      "suppressedFromDiscovery": false
+    },
+    "holdings": {
+      "total": 1,
+      "suppressedFromDiscovery": 0,
+      "notSuppressedFromDiscovery": 1
+    },
+    "items": {
+      "total": 1,
+      "suppressedFromDiscovery": 0,
+      "suppressedByHoldings": 0,
+      "suppressedFromDiscoveryOrByHoldings": 0,
+      "notSuppressedFromDiscovery": 1
+    }
+  },
+  "aggregates": {
+    "allRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 002"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/central",
+          "linkText": "Central"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "11111111-1111-4111-8111-111111111111",
+            "name": "book"
+          }
+        ]
+      }
+    },
+    "notSuppressedFromDiscoveryRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 002"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/central",
+          "linkText": "Central"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "11111111-1111-4111-8111-111111111111",
+            "name": "book"
+          }
+        ]
+      }
+    }
+  },
+  "referenceValues": {
+    "instanceFormats": [
+      {
+        "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "text"
+      }
+    ],
+    "natureOfContentTerms": [],
+    "instanceType": {
+      "id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "name": "text"
+    }
+  }
+}

--- a/src/test/resources/__files/responses/instance_summary_response.json
+++ b/src/test/resources/__files/responses/instance_summary_response.json
@@ -6,9 +6,6 @@
   },
   "isBoundWith": false,
   "recordCounts": {
-    "instance": {
-      "suppressedFromDiscovery": false
-    },
     "holdings": {
       "total": 1,
       "suppressedFromDiscovery": 0,

--- a/src/test/resources/__files/responses/instance_summary_sparse_central_response.json
+++ b/src/test/resources/__files/responses/instance_summary_sparse_central_response.json
@@ -1,0 +1,50 @@
+{
+  "instance": {
+    "id": "e6bc03c6-c137-4221-b679-a7c5c31f986c",
+    "title": "Sparse central summary"
+  },
+  "isBoundWith": false,
+  "recordCounts": {
+    "holdings": {
+      "total": 1,
+      "suppressedFromDiscovery": 0,
+      "notSuppressedFromDiscovery": 1
+    },
+    "items": {
+      "total": 1,
+      "suppressedFromDiscovery": 0,
+      "suppressedByHoldings": 0,
+      "suppressedFromDiscoveryOrByHoldings": 0,
+      "notSuppressedFromDiscovery": 1
+    }
+  },
+  "aggregates": {
+    "allRecords": {
+      "itemDerivedFields": {},
+      "electronicAccess": [
+        null,
+        {
+          "uri": " ",
+          "linkText": "Blank URI"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          null,
+          {
+            "name": "unknown material"
+          }
+        ]
+      }
+    },
+    "notSuppressedFromDiscoveryRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 020"
+      },
+      "electronicAccess": [],
+      "referenceValues": {
+        "itemMaterialTypes": []
+      }
+    }
+  }
+}

--- a/src/test/resources/__files/responses/instance_summary_sparse_member_response.json
+++ b/src/test/resources/__files/responses/instance_summary_sparse_member_response.json
@@ -1,0 +1,16 @@
+{
+  "instance": {
+    "id": "e6bc03c6-c137-4221-b679-a7c5c31f986c",
+    "title": "Sparse member summary"
+  },
+  "aggregates": {
+    "allRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "CN 010"
+      }
+    },
+    "notSuppressedFromDiscoveryRecords": {
+      "itemDerivedFields": {}
+    }
+  }
+}

--- a/src/test/resources/mappings/holdings_facet.json
+++ b/src/test/resources/mappings/holdings_facet.json
@@ -6,6 +6,24 @@
         "urlPath": "/search/instances/facets",
         "queryParameters": {
           "query": {
+            "contains": "e6bc03c6-c137-4221-b679-a7c5c31f986c"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/holdings_facet_with_two_tenants_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/search/instances/facets",
+        "queryParameters": {
+          "query": {
             "contains": "d41d9172-1869-11eb-adc1-0242ac120002"
           }
         }

--- a/src/test/resources/mappings/instance_summary.json
+++ b/src/test/resources/mappings/instance_summary.json
@@ -1,0 +1,56 @@
+{
+  "mappings": [
+    {
+      "priority": 1,
+      "request": {
+        "method": "GET",
+        "urlPath": "/instance-storage/instances/e6bc03c6-c137-4221-b679-a7c5c31f986c/summary",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test1"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/instance_summary_member_1_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "priority": 1,
+      "request": {
+        "method": "GET",
+        "urlPath": "/instance-storage/instances/e6bc03c6-c137-4221-b679-a7c5c31f986c/summary",
+        "headers": {
+          "x-okapi-tenant": {
+            "equalTo": "test2"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/instance_summary_member_2_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "priority": 2,
+      "request": {
+        "method": "GET",
+        "urlPath": "/instance-storage/instances/e6bc03c6-c137-4221-b679-a7c5c31f986c/summary"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "responses/instance_summary_response.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Purpose
Proxys new instance summary endpoint. See: https://folio-org.atlassian.net/browse/EDGEINV-34. Also: https://folio-org.atlassian.net/wiki/spaces/DD/pages/2026962945/Inventory+instance+summary for architecture.

### Approach
Performs fan-out for tenants that have holdings according to mod-search facets. This pattern is already used in the existing implementation, but should be much faster now since we're fetching the instance summary rather than all holdings and items.

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [x] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
See https://folio-org.atlassian.net/browse/UXPROD-5913

### Learning and Resources (if applicable)
https://folio-org.atlassian.net/wiki/spaces/DD/pages/2026962945/Inventory+instance+summary

