### PR TITLE
chore(EDGEINV-38): Upgrade edge-common-spring in edge-inventory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>21</java.version>
-    <edge-common-spring.version>4.0.0</edge-common-spring.version>
+    <edge-common-spring.version>4.0.1</edge-common-spring.version>
     <openapi-generator.version>7.20.0</openapi-generator.version>
     <folio-spring-support.version>10.0.0</folio-spring-support.version>
     <edge-inventory.yaml.file>${project.basedir}/src/main/resources/swagger.api/edge-inventory.yaml</edge-inventory.yaml.file>


### PR DESCRIPTION
### Purpose
Upgrade version of edge-common-spring to 4.0.1 to fix issues with concurrent requests (https://folio-org.atlassian.net/browse/EDGCMNSPR-69)